### PR TITLE
Additional browser js refactoring with CanvasState

### DIFF
--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -339,7 +339,12 @@ class BaseEdit(View):
         """
         annotated = np.copy(self.annotated[frame, ..., self.feature])
 
+        # any brush
         in_original = np.any(np.isin(annotated, brush_value))
+
+        # conversion brush
+        if target_value != 0:
+            target_in_original = np.any(np.isin(annotated, target_value))
 
         annotated_draw = np.where(annotated == target_value, brush_value, annotated)
         annotated_erase = np.where(annotated == brush_value, target_value, annotated)
@@ -360,6 +365,12 @@ class BaseEdit(View):
                 annotated[brush_area] = annotated_erase[brush_area]
 
         in_modified = np.any(np.isin(annotated, brush_value))
+
+        # conversion brush
+        if target_value != 0:
+            target_in_modified = np.any(np.isin(annotated, target_value))
+            if target_in_original and not target_in_modified:
+                self.del_cell_info(del_label=target_value, frame=frame)
 
         # cell deletion
         if in_original and not in_modified:

--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -349,8 +349,13 @@ class BaseEdit(View):
         annotated_draw = np.where(annotated == target_value, brush_value, annotated)
         annotated_erase = np.where(annotated == brush_value, target_value, annotated)
 
-        for loc in trace:
-            # each element of trace is an array with [y,x] coordinates of array
+        # remove any duplicate coords that may have gotten through
+        unique_trace = set([tuple(t) for t in trace])
+
+        # TODO: could try speeding this up a bit by restricting the area of array
+        # that this applies to--brush only affects a small portion of the whole image
+        for loc in unique_trace:
+            # each element of trace is a tuple holding (y, x) coordinates of img
             x_loc = loc[1]
             y_loc = loc[0]
 

--- a/browser/static/js/canvas.js
+++ b/browser/static/js/canvas.js
@@ -46,6 +46,18 @@ class CanvasState {
     this.isSpacedown = false;
   }
 
+  reset(scale, padding) {
+    this.scale = scale;
+    this.zoom = 100;
+
+    // set viewing coords back to show full image
+    this.sx = 0;
+    this.sy = 0;
+    this.sWidth = this.width;
+    this.sHeight = this.height;
+    this.setBorders(padding);
+  }
+
   get segArray() {
     return this._segArray;
   }

--- a/browser/static/js/canvas.js
+++ b/browser/static/js/canvas.js
@@ -38,7 +38,7 @@ class CanvasState {
     // store as part of object to be able to get current label
     this._segArray = null;
 
-    this.scale = scale;
+    this._scale = scale;
 
     this.topBorder = new Path2D();
     this.bottomBorder = new Path2D();
@@ -48,16 +48,23 @@ class CanvasState {
     this.isSpacedown = false;
   }
 
-  reset(scale) {
-    this.scale = scale;
-    this.zoom = 100;
+  get scale() {
+    return this._scale;
+  }
 
-    // set viewing coords back to show full image
-    this.sx = 0;
-    this.sy = 0;
-    this.sWidth = this.width;
-    this.sHeight = this.height;
-    this.setBorders();
+  set scale(newScale) {
+    // no need to reset zoom, etc if scale has not actually changed
+    if (this.scale !== newScale) {
+      this._scale = newScale;
+      this.zoom = 100;
+
+      // set viewing coords back to show full image
+      this.sx = 0;
+      this.sy = 0;
+      this.sWidth = this.width;
+      this.sHeight = this.height;
+      this.setBorders();
+    }
   }
 
   get segArray() {

--- a/browser/static/js/canvas.js
+++ b/browser/static/js/canvas.js
@@ -6,6 +6,8 @@ class CanvasState {
     this.width = width;
     this.height = height;
 
+    this.padding = padding;
+
     // attributes for viewing the canvas.
     this.sx = 0;
     this.sy = 0;
@@ -23,8 +25,8 @@ class CanvasState {
     this.rawX = 0;
     this.rawY = 0;
     // adjusted for padding
-    this.canvasPosX = -1 * padding;
-    this.canvasPosY = -1 * padding;
+    this.canvasPosX = -1 * this.padding;
+    this.canvasPosY = -1 * this.padding;
     // coordinates in original image (used for actions, labels, etc)
     this.imgX = null;
     this.imgY = null;
@@ -46,7 +48,7 @@ class CanvasState {
     this.isSpacedown = false;
   }
 
-  reset(scale, padding) {
+  reset(scale) {
     this.scale = scale;
     this.zoom = 100;
 
@@ -55,7 +57,7 @@ class CanvasState {
     this.sy = 0;
     this.sWidth = this.width;
     this.sHeight = this.height;
-    this.setBorders(padding);
+    this.setBorders();
   }
 
   get segArray() {
@@ -92,14 +94,14 @@ class CanvasState {
     );
   }
 
-  updateCursorPosition(x, y, padding) {
+  updateCursorPosition(x, y) {
     // store raw mouse position, in case of pan without mouse movement
     this.rawX = x;
     this.rawY = y;
 
     // convert to viewing pane position, to check whether to access label underneath
-    this.canvasPosX = x - padding;
-    this.canvasPosY = y - padding;
+    this.canvasPosX = x - this.padding;
+    this.canvasPosY = y - this.padding;
 
     // convert to image indices, to use for actions and getting label
     if (this.inRange()) {
@@ -111,37 +113,37 @@ class CanvasState {
     }
   }
 
-  setBorders(padding) {
+  setBorders() {
     const scaledWidth = this.scaledWidth;
     const scaledHeight = this.scaledHeight;
 
     // create paths for recoloring borders
     this.topBorder = new Path2D();
     this.topBorder.moveTo(0, 0);
-    this.topBorder.lineTo(padding, padding);
-    this.topBorder.lineTo(scaledWidth + padding, padding);
-    this.topBorder.lineTo(scaledWidth + 2 * padding, 0);
+    this.topBorder.lineTo(this.padding, this.padding);
+    this.topBorder.lineTo(scaledWidth + this.padding, this.padding);
+    this.topBorder.lineTo(scaledWidth + 2 * this.padding, 0);
     this.topBorder.closePath();
 
     this.bottomBorder = new Path2D();
-    this.bottomBorder.moveTo(0, scaledHeight + 2 * padding);
-    this.bottomBorder.lineTo(padding, scaledHeight + padding);
-    this.bottomBorder.lineTo(scaledWidth + padding, scaledHeight + padding);
-    this.bottomBorder.lineTo(scaledWidth + 2 * padding, scaledHeight + 2 * padding);
+    this.bottomBorder.moveTo(0, scaledHeight + 2 * this.padding);
+    this.bottomBorder.lineTo(this.padding, scaledHeight + this.padding);
+    this.bottomBorder.lineTo(scaledWidth + this.padding, scaledHeight + this.padding);
+    this.bottomBorder.lineTo(scaledWidth + 2 * this.padding, scaledHeight + 2 * this.padding);
     this.bottomBorder.closePath();
 
     this.leftBorder = new Path2D();
     this.leftBorder.moveTo(0, 0);
-    this.leftBorder.lineTo(0, scaledHeight + 2 * padding);
-    this.leftBorder.lineTo(padding, scaledHeight + padding);
-    this.leftBorder.lineTo(padding, padding);
+    this.leftBorder.lineTo(0, scaledHeight + 2 * this.padding);
+    this.leftBorder.lineTo(this.padding, scaledHeight + this.padding);
+    this.leftBorder.lineTo(this.padding, this.padding);
     this.leftBorder.closePath();
 
     this.rightBorder = new Path2D();
-    this.rightBorder.moveTo(scaledWidth + 2 * padding, 0);
-    this.rightBorder.lineTo(scaledWidth + padding, padding);
-    this.rightBorder.lineTo(scaledWidth + padding, scaledHeight + padding);
-    this.rightBorder.lineTo(scaledWidth + 2 * padding, scaledHeight + 2 * padding);
+    this.rightBorder.moveTo(scaledWidth + 2 * this.padding, 0);
+    this.rightBorder.lineTo(scaledWidth + this.padding, this.padding);
+    this.rightBorder.lineTo(scaledWidth + this.padding, scaledHeight + this.padding);
+    this.rightBorder.lineTo(scaledWidth + 2 * this.padding, scaledHeight + 2 * this.padding);
     this.rightBorder.closePath();
   }
 
@@ -211,13 +213,13 @@ class CanvasState {
     }
   }
 
-  drawImage(ctx, image, padding = 0) {
-    ctx.clearRect(padding, padding, this.width, this.height);
+  drawImage(ctx, image) {
+    ctx.clearRect(this.padding, this.padding, this.width, this.height);
     ctx.drawImage(
       image,
       this.sx, this.sy,
       this.sWidth, this.sHeight,
-      padding, padding,
+      this.padding, this.padding,
       this.scaledWidth,
       this.scaledHeight
     );

--- a/browser/static/js/canvas.js
+++ b/browser/static/js/canvas.js
@@ -89,6 +89,16 @@ class CanvasState {
     return this.scaledHeight + 2 * this.padding;
   }
 
+  /**
+  * Creates 2D path for clipping to prevent other object methods (eg, the brush)
+  * from drawing in blank padding regions.
+  */
+  get visibleRegion() {
+    const region = new Path2D();
+    region.rect(this.padding, this.padding, this.scaledWidth, this.scaledHeight);
+    return region;
+  }
+
   // clear the current trace
   clearTrace() {
     this.trace = [];

--- a/browser/static/js/canvas.js
+++ b/browser/static/js/canvas.js
@@ -117,8 +117,25 @@ class CanvasState {
     this._trace = [];
   }
 
+  // addToTrace should not add duplicate coordinates
   addToTrace() {
-    this._trace.push([this.imgY, this.imgX]);
+    const newCoord = [this.imgY, this.imgX];
+    if (!this.inTrace(newCoord)) {
+      this._trace.push(newCoord);
+    }
+  }
+
+  // check if coordinate already exists in trace
+  inTrace(newCoord) {
+    let duplicate = false;
+    for (var i=0; i < this._trace.length; i++) {
+      let coord = this._trace[i];
+      if (coord[0] === newCoord[0] && coord[1] === newCoord[1]) {
+        duplicate = true;
+        break;
+      }
+    }
+    return duplicate;
   }
 
   // check if the mouse position in canvas matches to a displayed part of image

--- a/browser/static/js/canvas.js
+++ b/browser/static/js/canvas.js
@@ -203,7 +203,9 @@ class CanvasState {
   }
 
   drawBorders(ctx) {
+    // save now, restore at end to prevent overwriting current ctx fillStyle
     ctx.save();
+
     // left border
     ctx.fillStyle = (Math.floor(this.sx) === 0) ? 'white' : 'black';
     ctx.fill(this.leftBorder);

--- a/browser/static/js/canvas.js
+++ b/browser/static/js/canvas.js
@@ -18,7 +18,7 @@ class CanvasState {
 
     // attributes for mouse on the canvas.
     this.isPressed = false;
-    this.trace = [];
+    this._trace = [];
 
     // mouse coords
     // mouse position on canvas, no adjustment for padding
@@ -106,9 +106,19 @@ class CanvasState {
     return region;
   }
 
+  // only time trace needs to be accessed externally
+  // is to be passed to caliban.py in JSON format
+  get trace() {
+    return JSON.stringify(this._trace);
+  }
+
   // clear the current trace
   clearTrace() {
-    this.trace = [];
+    this._trace = [];
+  }
+
+  addToTrace() {
+    this._trace.push([this.imgY, this.imgX]);
   }
 
   // check if the mouse position in canvas matches to a displayed part of image

--- a/browser/static/js/canvas.js
+++ b/browser/static/js/canvas.js
@@ -81,6 +81,14 @@ class CanvasState {
     return this.scale * this.height;
   }
 
+  get paddedWidth() {
+    return this.scaledWidth + 2 * this.padding;
+  }
+
+  get paddedHeight() {
+    return this.scaledHeight + 2 * this.padding;
+  }
+
   // clear the current trace
   clearTrace() {
     this.trace = [];
@@ -118,32 +126,35 @@ class CanvasState {
     const scaledHeight = this.scaledHeight;
 
     // create paths for recoloring borders
+    // TODO: would it be more intuitive to move the line to this.paddedWidth - this.padding
+    // instead of scaledWidth + this.padding? same value but maybe it'll make the path
+    // a little more clear
     this.topBorder = new Path2D();
     this.topBorder.moveTo(0, 0);
     this.topBorder.lineTo(this.padding, this.padding);
     this.topBorder.lineTo(scaledWidth + this.padding, this.padding);
-    this.topBorder.lineTo(scaledWidth + 2 * this.padding, 0);
+    this.topBorder.lineTo(this.paddedWidth, 0);
     this.topBorder.closePath();
 
     this.bottomBorder = new Path2D();
-    this.bottomBorder.moveTo(0, scaledHeight + 2 * this.padding);
+    this.bottomBorder.moveTo(0, this.paddedHeight);
     this.bottomBorder.lineTo(this.padding, scaledHeight + this.padding);
     this.bottomBorder.lineTo(scaledWidth + this.padding, scaledHeight + this.padding);
-    this.bottomBorder.lineTo(scaledWidth + 2 * this.padding, scaledHeight + 2 * this.padding);
+    this.bottomBorder.lineTo(this.paddedWidth, this.paddedHeight);
     this.bottomBorder.closePath();
 
     this.leftBorder = new Path2D();
     this.leftBorder.moveTo(0, 0);
-    this.leftBorder.lineTo(0, scaledHeight + 2 * this.padding);
+    this.leftBorder.lineTo(0, this.paddedHeight);
     this.leftBorder.lineTo(this.padding, scaledHeight + this.padding);
     this.leftBorder.lineTo(this.padding, this.padding);
     this.leftBorder.closePath();
 
     this.rightBorder = new Path2D();
-    this.rightBorder.moveTo(scaledWidth + 2 * this.padding, 0);
+    this.rightBorder.moveTo(this.paddedWidth, 0);
     this.rightBorder.lineTo(scaledWidth + this.padding, this.padding);
     this.rightBorder.lineTo(scaledWidth + this.padding, scaledHeight + this.padding);
-    this.rightBorder.lineTo(scaledWidth + 2 * this.padding, scaledHeight + 2 * this.padding);
+    this.rightBorder.lineTo(this.paddedWidth, this.paddedHeight);
     this.rightBorder.closePath();
   }
 

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -669,13 +669,10 @@ var edit_mode;
 var answer = '(SPACE=YES / ESC=NO)';
 var project_id;
 
-var tracks;
-
 // objects that need to remain globally accessible for now
 var mode = new Mode(Modes.none, {});
 var brush;
 var adjuster;
-var cursor;
 var state;
 
 /**

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -843,9 +843,9 @@ function render_edit_image(ctx) {
   if (rgb && rendering_raw) {
     render_raw_image(ctx);
   } else if (!rgb && !display_labels) {
-    this.state.drawImage(ctx, adjuster.preCompRaw, padding);
+    this.state.drawImage(ctx, adjuster.preCompRaw);
   } else {
-    this.state.drawImage(ctx, adjuster.postCompImg, padding);
+    this.state.drawImage(ctx, adjuster.postCompImg);
   }
   ctx.save();
   const region = new Path2D();
@@ -860,14 +860,14 @@ function render_edit_image(ctx) {
 }
 
 function render_raw_image(ctx) {
-  this.state.drawImage(ctx, adjuster.contrastedRaw, padding);
+  this.state.drawImage(ctx, adjuster.contrastedRaw);
 }
 
 function render_annotation_image(ctx) {
   if (rgb && !display_labels) {
-    this.state.drawImage(ctx, adjuster.postCompImg, padding);
+    this.state.drawImage(ctx, adjuster.postCompImg);
   } else {
-    this.state.drawImage(ctx, adjuster.preCompSeg, padding);
+    this.state.drawImage(ctx, adjuster.preCompSeg);
   }
 }
 
@@ -936,7 +936,7 @@ function setCanvasDimensions(rawDims) {
   const scale = Math.min(scaleX, scaleY);
 
   // change the scale and reset viewing window attributes
-  state.reset(scale, padding);
+  state.reset(scale);
 
   // set canvases size according to scale
   document.getElementById('canvas').width = state.scaledWidth + 2 * padding;
@@ -993,7 +993,7 @@ function updateMousePos(x, y) {
   const oldImgX = state.imgX;
   const oldImgY = state.imgY;
 
-  state.updateCursorPosition(x, y, padding);
+  state.updateCursorPosition(x, y);
 
   // if cursor has actually changed location in image
   if (oldImgX !== state.imgX || oldImgY !== state.imgY) {

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -848,9 +848,7 @@ function render_edit_image(ctx) {
     this.state.drawImage(ctx, adjuster.postCompImg);
   }
   ctx.save();
-  const region = new Path2D();
-  region.rect(padding, padding, state.scaledWidth, state.scaledHeight);
-  ctx.clip(region);
+  ctx.clip(state.visibleRegion);
   ctx.imageSmoothingEnabled = true;
 
   // draw brushview on top of cells/annotations

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -932,7 +932,7 @@ function setCanvasDimensions(rawDims) {
   const scale = Math.min(scaleX, scaleY);
 
   // change the scale and reset viewing window attributes
-  state.reset(scale);
+  state.scale = scale;
 
   // set canvases size according to scale
   document.getElementById('canvas').width = state.paddedWidth;

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -649,26 +649,30 @@ const Modes = Object.freeze({
   drawing: 7
 });
 
+// TODO: object that holds file info such as below attributes?
 const maxLabelsMap = new Map();
+var current_frame = 0;
+var max_frames;
+var feature_max;
+var channelMax;
+var tracks;
+
+// TODO: highlighter object that moves some attributes out of Mode?
+var current_highlight;
 
 let rgb;
 
 var rendering_raw = false;
 var display_labels;
 
-var current_frame = 0;
-var current_highlight;
-var max_frames;
-var feature_max;
-var channelMax;
-var tracks;
-var mode = new Mode(Modes.none, {});
 var edit_mode;
 var answer = '(SPACE=YES / ESC=NO)';
 var project_id;
 
 var tracks;
 
+// objects that need to remain globally accessible for now
+var mode = new Mode(Modes.none, {});
 var brush;
 var adjuster;
 var cursor;
@@ -1200,6 +1204,8 @@ function startCaliban(filename, settings) {
     });
 
     // bind scroll wheel, change contrast of raw when scrolled
+    // TODO: it would be nice to add in waitForFinalEvent here
+    // with a short timer for brightness/contrast adjustments
     canvasElement.addEventListener('wheel', (e) => handleScroll(e));
 
     // mousedown for click&drag/handle_draw DIFFERENT FROM CLICK

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -874,8 +874,6 @@ function render_annotation_image(ctx) {
 function render_image_display() {
   const ctx = document.getElementById('canvas').getContext('2d');
   ctx.imageSmoothingEnabled = false;
-  // TODO: is there a corresponding ctx.restore to match this ctx.save?
-  ctx.save();
   ctx.clearRect(
     0, 0,
     2 * padding + state.scaledWidth,

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -937,9 +937,8 @@ function setCanvasDimensions(rawDims) {
   // pick scale that accomodates both dimensions; can be less than 1
   const scale = Math.min(scaleX, scaleY);
 
-  state.zoom = 100;
-  state.scale = scale;
-  state.setBorders(padding);
+  // change the scale and reset viewing window attributes
+  state.reset(scale, padding);
 
   // set canvases size according to scale
   document.getElementById('canvas').width = state.scaledWidth + 2 * padding;
@@ -1185,9 +1184,10 @@ function startCaliban(filename, settings) {
     // resize the canvas every time the window is resized
     window.addEventListener('resize', function() {
       waitForFinalEvent(() => {
+        // why do we need to clear mode here?
         mode.clear();
         setCanvasDimensions(payload.dimensions);
-        brush.refreshView();
+        render_image_display();
       }, 500, 'canvasResize');
     });
 

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -876,8 +876,8 @@ function render_image_display() {
   ctx.imageSmoothingEnabled = false;
   ctx.clearRect(
     0, 0,
-    2 * padding + state.scaledWidth,
-    2 * padding + state.scaledHeight
+    state.paddedWidth,
+    state.paddedHeight
   );
 
   if (edit_mode) {
@@ -939,8 +939,8 @@ function setCanvasDimensions(rawDims) {
   state.reset(scale);
 
   // set canvases size according to scale
-  document.getElementById('canvas').width = state.scaledWidth + 2 * padding;
-  document.getElementById('canvas').height = state.scaledHeight + 2 * padding;
+  document.getElementById('canvas').width = state.paddedWidth;
+  document.getElementById('canvas').height = state.paddedHeight;
 }
 
 // adjust contrast, brightness, or zoom upon mouse scroll

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -649,8 +649,6 @@ const Modes = Object.freeze({
   drawing: 7
 });
 
-const padding = 5;
-
 const maxLabelsMap = new Map();
 
 let rgb;
@@ -1095,6 +1093,8 @@ function action(action, info, frame = current_frame) {
 }
 
 function startCaliban(filename, settings) {
+  const padding = 5;
+
   rgb = settings.rgb;
   current_highlight = settings.rgb;
   display_labels = !settings.rgb;

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -428,7 +428,7 @@ class Mode {
 
   handle_draw() {
     action('handle_draw', {
-      trace: JSON.stringify(state.trace), // stringify array so it doesn't get messed up
+      trace: state.trace, // trace is formatted properly by getter function
       target_value: brush.target, // value that we're overwriting
       brush_value: brush.value, // we don't update caliban with edit_value, etc each time they change
       brush_size: brush.size, // so we need to pass them in as args
@@ -965,7 +965,7 @@ function handleMousedown(evt) {
           brush.threshY = state.imgY;
         } else if (mode.kind !== Modes.prompt) {
           // not if turning on conv brush
-          state.trace.push([state.imgY, state.imgX]);
+          state.addToTrace();
         }
       }
     }
@@ -976,7 +976,7 @@ function helper_brush_draw() {
   if (state.isCursorPressed() && !state.isSpacedown) {
     // update mouse_trace, but not if turning on conv brush
     if (mode.kind !== Modes.prompt) {
-      state.trace.push([state.imgY, state.imgX]);
+      state.addToTrace();
     }
   } else {
     brush.clearView();


### PR DESCRIPTION
## What
* Further refactoring of javascript with focus on CanvasState (make `padding` an object attribute instead of global variable, add methods to handle trace when drawing)
* Updates `action_handle_draw` functionality in `caliban.py` backend

## Why
* Reduce globally scoped variables (another step towards improved modularity of code)
* Abstraction of mouse trace behavior into CanvasState methods leads to easier implementation of drawing with mouse events
* Close #158 (improves efficiency of drawing action)
* Close #203 (prevents conversion brush cell info bug)
