### PR TITLE
File loader schema bridge

### DIFF
--- a/browser/blueprints.py
+++ b/browser/blueprints.py
@@ -213,7 +213,6 @@ def load(bucket, filename):
     # arg is 'false' which gets parsed to True if casting to bool
     rgb = request.args.get('rgb', default='false', type=str)
     rgb = bool(distutils.util.strtobool(rgb))
-    bucket = request.args.get('input-bucket', default=S3_INPUT_BUCKET, type=str)
 
     if not is_trk_file(path) and not is_npz_file(path):
         ext = os.path.splitext(path)[-1]

--- a/browser/blueprints.py
+++ b/browser/blueprints.py
@@ -48,11 +48,13 @@ class InvalidExtension(Exception):
         rv['message'] = self.message
         return rv
 
+
 @bp.errorhandler(InvalidExtension)
 def handle_invalid_usage(error):
     response = jsonify(error.to_dict())
     response.status_code = error.status_code
     return response
+
 
 @bp.errorhandler(Exception)
 def handle_exception(error):
@@ -291,12 +293,12 @@ def get_edit(project):
 def make_settings(filename):
     """Returns a dictionary of settings to send to the front-end."""
     folders = re.split('__', filename)
-    
+
     input_bucket = folders[0] if len(folders) > 1 else S3_INPUT_BUCKET
     output_bucket = folders[1] if len(folders) > 2 else S3_OUTPUT_BUCKET
     start_of_path = min(len(folders) - 1, 2)
     path = '__'.join(folders[start_of_path:])
-    
+
     rgb = request.args.get('rgb', default='false', type=str)
     pixel_only = request.args.get('pixel_only', default='false', type=str)
     label_only = request.args.get('label_only', default='false', type=str)

--- a/browser/blueprints.py
+++ b/browser/blueprints.py
@@ -59,7 +59,7 @@ def upload_file(project_id):
 
     # Call function in caliban.py to save data file and send to S3 bucket
     edit = get_edit(project)
-    filename = project.filename
+    filename = project.path
     if is_trk_file(filename):
         edit.action_save_track(bucket)
     elif is_npz_file(filename):
@@ -303,7 +303,7 @@ def shortcut(filename):
 
 def get_edit(project):
     """Factory for Edit objects"""
-    filename = project.filename
+    filename = project.path
     if is_npz_file(filename):
         return ZStackEdit(project)
     elif is_trk_file(filename):

--- a/browser/blueprints.py
+++ b/browser/blueprints.py
@@ -293,6 +293,7 @@ def make_settings(filename):
     """Returns a dictionary of settings to send to the front-end."""
     folders = re.split('__', filename)
 
+    # TODO: better parsing when buckets are not present
     input_bucket = folders[0] if len(folders) > 1 else S3_INPUT_BUCKET
     output_bucket = folders[1] if len(folders) > 2 else S3_OUTPUT_BUCKET
     start_of_path = min(len(folders) - 1, 2)

--- a/browser/blueprints.py
+++ b/browser/blueprints.py
@@ -239,24 +239,10 @@ def tool():
         return redirect('/')
 
     filename = request.form['filename']
-
     current_app.logger.info('%s is filename', filename)
+    new_filename = 'test__{}'.format(filename)
 
-    # TODO: better name template?
-    new_filename = 'caliban-input__caliban-output__test__{}'.format(filename)
-
-    # if no options passed (how this route will be for now),
-    # still want to pass in default settings
-    rgb = request.args.get('rgb', default='false', type=str)
-    pixel_only = request.args.get('pixel_only', default='false', type=str)
-    label_only = request.args.get('label_only', default='false', type=str)
-
-    # Using distutils to cast string arguments to bools
-    settings = {
-        'rgb': bool(distutils.util.strtobool(rgb)),
-        'pixel_only': bool(distutils.util.strtobool(pixel_only)),
-        'label_only': bool(distutils.util.strtobool(label_only))
-    }
+    settings = make_settings()
 
     if is_trk_file(new_filename):
         filetype = 'track'
@@ -289,15 +275,7 @@ def shortcut(filename):
     request to access a specific data file that has been preloaded to the
     input S3 bucket (ex. http://127.0.0.1:5000/test.npz).
     """
-    rgb = request.args.get('rgb', default='false', type=str)
-    pixel_only = request.args.get('pixel_only', default='false', type=str)
-    label_only = request.args.get('label_only', default='false', type=str)
-
-    settings = {
-        'rgb': bool(distutils.util.strtobool(rgb)),
-        'pixel_only': bool(distutils.util.strtobool(pixel_only)),
-        'label_only': bool(distutils.util.strtobool(label_only))
-    }
+    settings = make_settings()
 
     if is_trk_file(filename):
         filetype = 'track'
@@ -332,3 +310,21 @@ def get_edit(project):
         # don't use RGB mode with track files
         return TrackEdit(project)
     return BaseEdit(project)
+
+def make_settings():
+    """Returns a dictionary of settings to send to the front-end."""
+    rgb = request.args.get('rgb', default='false', type=str)
+    pixel_only = request.args.get('pixel_only', default='false', type=str)
+    label_only = request.args.get('label_only', default='false', type=str)
+    input_bucket = request.args.get('input_bucket', default=S3_INPUT_BUCKET, type=str)
+    output_bucket = request.args.get('output_bucket', default=S3_OUTPUT_BUCKET, type=str)
+
+    settings = {
+        'rgb': bool(distutils.util.strtobool(rgb)),
+        'pixel_only': bool(distutils.util.strtobool(pixel_only)),
+        'label_only': bool(distutils.util.strtobool(label_only)),
+        'input_bucket': input_bucket,
+        'output_bucket': output_bucket,
+    }
+
+    return settings

--- a/browser/blueprints.py
+++ b/browser/blueprints.py
@@ -47,15 +47,13 @@ def handle_exception(error):
     return jsonify({'message': str(error)}), 500
 
 
-@bp.route('/upload_file/<int:project_id>', methods=['GET', 'POST'])
-def upload_file(project_id):
+@bp.route('/upload_file/<bucket>/<int:project_id>', methods=['GET', 'POST'])
+def upload_file(bucket, project_id):
     """Upload .trk/.npz data file to AWS S3 bucket."""
     start = timeit.default_timer()
     project = Project.get(project_id)
     if not project:
         return jsonify({'error': 'project_id not found'}), 404
-
-    bucket = request.args.get('output-bucket', default=S3_OUTPUT_BUCKET, type=str)
 
     # Call function in caliban.py to save data file and send to S3 bucket
     edit = get_edit(project)
@@ -178,8 +176,8 @@ def redo(project_id):
     return jsonify(payload)
 
 
-@bp.route('/load/<filename>', methods=['POST'])
-def load(filename):
+@bp.route('/load/<bucket>/<filename>', methods=['POST'])
+def load(bucket, filename):
     """
     Initate TrackEdit/ZStackEdit object and load object to database.
     Send specific attributes of the object to the .js file.

--- a/browser/blueprints_test.py
+++ b/browser/blueprints_test.py
@@ -71,25 +71,20 @@ def test_upload_file(mocker, client):
     filename_trk = 'filename.trk'
     input_bucket = 'input_bucket'
     output_bucket = 'output_bucket'
-    path = 'path'
 
     # Create a project.
     project = models.Project.create(
-        filename=filename_npz,
-        input_bucket=input_bucket,
-        output_bucket=output_bucket,
-        path=path)
+        bucket=input_bucket,
+        path=filename_npz)
 
-    response = client.get('/upload_file/{}'.format(project.id))
+    response = client.get(f'/upload_file/{output_bucket}/{project.id}')
     assert response.status_code == 302
 
     project = models.Project.create(
-        filename=filename_trk,
-        input_bucket=input_bucket,
-        output_bucket=output_bucket,
-        path=path)
+        bucket=input_bucket,
+        path=filename_trk)
 
-    response = client.get('/upload_file/{}'.format(project.id))
+    response = client.get(f'/upload_file/{output_bucket}/{project.id}')
     assert response.status_code == 302
 
 
@@ -109,10 +104,8 @@ def test_change_display(mocker, client):
 
         # Create a project.
         project = models.Project.create(
-            filename=filename,
-            input_bucket='input_bucket',
-            output_bucket='output_bucket',
-            path='path')
+            bucket='input_bucket',
+            path=filename)
 
         response = client.post('/changedisplay/{}/frame/0'.format(project.id))
         # TODO: test correctness
@@ -140,11 +133,7 @@ def test_action(client):
 def test_load(client, mocker):
     # TODO: parsing the filename is a bit awkward.
     in_bucket = 'inputBucket'
-    out_bucket = 'inputBucket'
-    filename = 'testfile'
-    caliban_file = '{}__{}__{}__{}__{}'.format(
-        in_bucket, out_bucket, 'subfolder1', 'subfolder2', filename
-    )
+    path = 'subfolder1__subfolder2__testfile'
 
     # Mock load from S3 bucket
     def load(self, *args):
@@ -155,17 +144,17 @@ def test_load(client, mocker):
     mocker.patch('blueprints.Project.load', load)
 
     # TODO: correctness tests
-    response = client.post('/load/{}.npz'.format(caliban_file))
+    response = client.post(f'/load/{in_bucket}/{path}.npz')
     assert response.status_code == 200
 
     # rgb mode only for npzs.
-    response = client.post('/load/{}.npz?rgb=true'.format(caliban_file))
+    response = client.post(f'/load/{in_bucket}/{path}.npz?rgb=true')
     assert response.status_code == 200
 
-    response = client.post('/load/{}.trk'.format(caliban_file))
+    response = client.post(f'/load/{in_bucket}/{path}.trk')
     assert response.status_code == 200
 
-    response = client.post('/load/{}.badext'.format(caliban_file))
+    response = client.post(f'/load/{in_bucket}/{path}.badext')
     assert response.status_code == 400
 
 
@@ -234,10 +223,8 @@ def test_undo(client, mocker):
 
     # Create a project
     project = models.Project.create(
-        filename='filename.npz',
-        input_bucket='input_bucket',
-        output_bucket='output_bucket',
-        path='path')
+        path='filename.npz',
+        bucket='input_bucket')
 
     # Undo with no action to undo silently does nothing
     response = client.post('/undo/{}'.format(project.id))
@@ -259,10 +246,8 @@ def test_redo(client, mocker):
 
     # Create a project
     project = models.Project.create(
-        filename='filename.npz',
-        input_bucket='input_bucket',
-        output_bucket='output_bucket',
-        path='path')
+        path='filename.npz',
+        bucket='input_bucket')
 
     # Redo with no action to redo silently does nothing
     response = client.post('/redo/{}'.format(project.id))

--- a/browser/blueprints_test.py
+++ b/browser/blueprints_test.py
@@ -182,7 +182,7 @@ def test_tool(client):
                            content_type='multipart/form-data',
                            data={'filename': filename})
     assert response.status_code == 400
-    assert 'error' in response.json
+    assert 'message' in response.json
 
 
 def test_shortcut(client):
@@ -205,7 +205,7 @@ def test_shortcut(client):
 
     response = client.get('/test-file.badext')
     assert response.status_code == 400
-    assert 'error' in response.json
+    assert 'message' in response.json
 
 
 def test_undo(client, mocker):

--- a/browser/caliban.py
+++ b/browser/caliban.py
@@ -583,7 +583,7 @@ class ZStackEdit(BaseEdit):
         self.y_changed = True
         self.create_cell_info(feature=self.feature)
 
-    def action_save_zstack(self):
+    def action_save_zstack(self, bucket):
         # save file to BytesIO object
         store_npz = io.BytesIO()
 
@@ -593,7 +593,7 @@ class ZStackEdit(BaseEdit):
 
         # store npz file object in bucket/path
         s3 = self.project._get_s3_client()
-        s3.upload_fileobj(store_npz, self.project.output_bucket, self.project.path)
+        s3.upload_fileobj(store_npz, bucket, self.project.path)
 
     def add_cell_info(self, add_label, frame):
         """Add a cell to the npz"""
@@ -783,7 +783,7 @@ class TrackEdit(BaseEdit):
 
         self.y_changed = self.labels_changed = True
 
-    def action_save_track(self):
+    def action_save_track(self, bucket):
         # clear any empty tracks before saving file
         empty_tracks = []
         for key in self.labels.tracks:
@@ -814,7 +814,7 @@ class TrackEdit(BaseEdit):
             # go to beginning of file object
             trk_file_obj.seek(0)
             s3 = self.project._get_s3_client()
-            s3.upload_fileobj(trk_file_obj, self.project.output_bucket, self.project.path)
+            s3.upload_fileobj(trk_file_obj, bucket, self.project.path)
 
         except Exception as e:
             print('Something Happened: ', e, file=sys.stderr)

--- a/browser/config.py
+++ b/browser/config.py
@@ -11,6 +11,8 @@ PORT = config('PORT', cast=int, default=5000)
 
 AWS_ACCESS_KEY_ID = config('AWS_ACCESS_KEY_ID', default='')
 AWS_SECRET_ACCESS_KEY = config('AWS_SECRET_ACCESS_KEY', default='')
+S3_INPUT_BUCKET = config('S3_INPUT_BUCKET', default='caliban-input')
+S3_OUTPUT_BUCKET = config('S3_OUTPUT_BUCKET', default='caliban-output')
 
 TEMPLATES_AUTO_RELOAD = config('TEMPLATES_AUTO_RELOAD', cast=bool, default=True)
 

--- a/browser/conftest.py
+++ b/browser/conftest.py
@@ -107,7 +107,7 @@ def zstack_project(app, mocker, request, db_session):
             return data
         mocker.patch('models.Project.load', load)
         mocker.patch('models.db.session', db_session)
-        project = Project.create('filename.npz', 'input_bucket', 'output_bucket', 'path')
+        project = Project.create('filename.npz', 'input_bucket')
         project.rgb = 'RGB' in request.node.name
         db_session.commit()
         return project
@@ -136,7 +136,7 @@ def track_project(app, mocker, request, db_session):
             return data
         mocker.patch('models.Project.load', load)
         mocker.patch('models.db.session', db_session)
-        project = Project.create('filename.trk', 'input_bucket', 'output_bucket', 'path')
+        project = Project.create('filename.trk', 'input_bucket')
         return project
 
 

--- a/browser/models.py
+++ b/browser/models.py
@@ -74,12 +74,12 @@ class Project(db.Model):
     # pylint: disable=E1101
     __tablename__ = 'projects'
     id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    token = db.Column(db.String(12), unique=True, nullable=False, index=True)
     createdAt = db.Column(db.TIMESTAMP, nullable=False, default=db.func.now())
     finished = db.Column(db.TIMESTAMP)
 
-    filename = db.Column(db.Text, nullable=False)
     path = db.Column(db.Text, nullable=False)
-    output_bucket = db.Column(db.Text, nullable=False)
+    source = db.Column(db.Enum(SourceEnum), nullable=False)
     height = db.Column(db.Integer, nullable=False)
     width = db.Column(db.Integer, nullable=False)
     num_frames = db.Column(db.Integer, nullable=False)

--- a/browser/models.py
+++ b/browser/models.py
@@ -72,8 +72,6 @@ class MutableNdarray(Mutable, np.ndarray):
 
 class SourceEnum(enum.Enum):
     s3 = 's3'
-    dropped = 'dropped'
-    lfs = 'lfs'
 
 
 class Project(db.Model):

--- a/browser/models.py
+++ b/browser/models.py
@@ -70,6 +70,12 @@ class MutableNdarray(Mutable, np.ndarray):
         self.changed()
 
 
+class SourceEnum(enum.Enum):
+    s3 = 's3'
+    dropped = 'dropped'
+    lfs = 'lfs'
+
+
 class Project(db.Model):
     """Project table definition."""
     # pylint: disable=E1101

--- a/browser/models.py
+++ b/browser/models.py
@@ -126,7 +126,7 @@ class Project(db.Model):
         start = timeit.default_timer()
         trial = self.load(path, bucket)
         logger.debug('Loaded file %s from S3 in %ss.',
-                     filename, timeit.default_timer() - start)
+                     path, timeit.default_timer() - start)
         raw = trial[raw_key]
         annotated = trial[annotated_key]
         # possible differences between single channel and rgb displays
@@ -151,7 +151,7 @@ class Project(db.Model):
         for feature in range(self.num_features):
             self.labels.create_cell_info(feature, annotated)
         # Overwrite cell_info with lineages to include cell relationships for .trk files
-        if is_trk_file(self.filename):
+        if is_trk_file(self.path):
             if len(trial['lineages']) != 1:
                 raise ValueError('Input file has multiple trials/lineages.')
             self.labels.cell_info = {0: trial['lineages'][0]}
@@ -223,10 +223,8 @@ class Project(db.Model):
         Wraps the Project constructor with logging and database commits.
 
         Args:
-            filename (str): filename including .npz or .trk extension
-            input_bucket (str): S3 bucket to download file
-            output_bucket (str): S3 bucket to upload file
             path (str): full path to download & upload file in buckets; includes filename
+            bucket (str): S3 bucket to download file
 
         Returns:
             Project: new row in the Project table

--- a/browser/models.py
+++ b/browser/models.py
@@ -110,15 +110,16 @@ class Project(db.Model):
     actions = db.relationship('Action', backref='project', foreign_keys='[Action.project_id]')
     num_actions = db.Column(db.Integer, default=0)
 
-    def __init__(self, filename, input_bucket, output_bucket, path,
+    def __init__(self, path, bucket,
                  raw_key='raw', annotated_key=None):
+
         init_start = timeit.default_timer()
 
         # Load data
         if annotated_key is None:
-            annotated_key = get_ann_key(filename)
+            annotated_key = get_ann_key(path)
         start = timeit.default_timer()
-        trial = self.load(filename, input_bucket, path)
+        trial = self.load(path, bucket)
         logger.debug('Loaded file %s from S3 in %ss.',
                      filename, timeit.default_timer() - start)
         raw = trial[raw_key]
@@ -129,9 +130,8 @@ class Project(db.Model):
             annotated = np.expand_dims(annotated, axis=0)
 
         # Record static project attributes
-        self.filename = filename
         self.path = path
-        self.output_bucket = output_bucket
+        self.source = SourceEnum.s3
         self.num_frames = raw.shape[0]
         self.height = raw.shape[1]
         self.width = raw.shape[2]
@@ -162,7 +162,7 @@ class Project(db.Model):
                              for i, frame in enumerate(annotated)]
 
         logger.debug('Initialized project for %s in %ss.',
-                     filename, timeit.default_timer() - init_start)
+                     path, timeit.default_timer() - init_start)
 
     @property
     def label_array(self):
@@ -181,16 +181,15 @@ class Project(db.Model):
             aws_secret_access_key=AWS_SECRET_ACCESS_KEY
         )
 
-    def load(self, filename, bucket, path):
+    def load(self, path, bucket):
         """
         Load a file from the S3 input bucket.
 
         Args:
-            filename (str): filename; used to check if loading .npz or .trk file
-            bucket (str): bucket to pull from on S3
             path (str): full path to the file within the bucket, including the filename
+            bucket (str): bucket to pull from on S3
         """
-        _load = get_load(filename)
+        _load = get_load(path)
         s3 = self._get_s3_client()
         response = s3.get_object(Bucket=bucket, Key=path)
         return _load(response['Body'].read())
@@ -213,7 +212,7 @@ class Project(db.Model):
         return project
 
     @staticmethod
-    def create(filename, input_bucket, output_bucket, path):
+    def create(path, bucket):
         """
         Create a new project.
         Wraps the Project constructor with logging and database commits.
@@ -228,7 +227,7 @@ class Project(db.Model):
             Project: new row in the Project table
         """
         start = timeit.default_timer()
-        new_project = Project(filename, input_bucket, output_bucket, path)
+        new_project = Project(path, bucket)
         # Assign a unique 12 character base64 token to the project
         while True:
             token = token_urlsafe(9)  # 9 bytes is 12 base64 characters

--- a/browser/models.py
+++ b/browser/models.py
@@ -11,6 +11,7 @@ import logging
 import tarfile
 import tempfile
 import timeit
+from secrets import token_urlsafe
 
 import boto3
 from flask import current_app

--- a/browser/models.py
+++ b/browser/models.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 
 import base64
 import copy
+import enum
 import io
 import json
 import logging

--- a/browser/models.py
+++ b/browser/models.py
@@ -228,6 +228,12 @@ class Project(db.Model):
         """
         start = timeit.default_timer()
         new_project = Project(filename, input_bucket, output_bucket, path)
+        # Assign a unique 12 character base64 token to the project
+        while True:
+            token = token_urlsafe(9)  # 9 bytes is 12 base64 characters
+            if not db.session.query(Project).filter_by(token=token).first():
+                new_project.token = token
+                break
         db.session.add(new_project)
         db.session.commit()
         new_project.create_memento('create_project', all_frames=True)

--- a/browser/models_test.py
+++ b/browser/models_test.py
@@ -18,9 +18,8 @@ def test_project_init(project):
     assert project.id is not None
     assert project.createdAt is not None
     assert project.finished is None  # None until project is done
-    assert project.filename is not None
     assert project.path is not None
-    assert project.output_bucket is not None
+    assert project.source is not None
     assert project.rgb is not None
     assert project.frame is not None
     assert project.channel is not None
@@ -62,10 +61,8 @@ def test_get(mocker, db_session):
         return {'raw': np.zeros((1, 1, 1, 1)), 'annotated': np.zeros((1, 1, 1, 1))}
     mocker.patch('models.Project.load', load)
     project = models.Project.create(
-        filename='filename',
-        input_bucket='input_bucket',
-        output_bucket='output_bucket',
-        path='path')
+        path='filename',
+        bucket='input_bucket')
 
     # test that the project can be found and is the same as the created one
     valid_id = project.id
@@ -83,10 +80,8 @@ def test_create(mocker, db_session):
     mocker.patch('models.db.session', db_session)
     mocker.patch('models.Project.load', load)
     project = models.Project.create(
-        filename='filename',
-        input_bucket='input_bucket',
-        output_bucket='output_bucket',
-        path='path')
+        path='filename',
+        bucket='input_bucket')
 
     # Test that an action has been initialized
     assert project.action is not None
@@ -201,10 +196,8 @@ def test_finish_project(mocker, db_session):
     mocker.patch('models.Project.load', load)
     mocker.patch('models.db.session', db_session)
     project = models.Project.create(
-        filename='filename',
-        input_bucket='input_bucket',
-        output_bucket='output_bucket',
-        path='path')
+        path='filename',
+        bucket='input_bucket')
 
     # test finish project
     project.finish()

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -459,11 +459,13 @@ var answer = "(SPACE=YES / ESC=NO)";
 var project_id = undefined;
 var brush;
 let mouse_trace = [];
+let inputBucket;
+let outputBucket;
 
 function upload_file(cb) {
   $.ajax({
     type: 'POST',
-    url: `${document.location.origin}/upload_file/${project_id}`,
+    url: `${document.location.origin}/upload_file/${outputBucket}/${project_id}`,
     async: true
   }).done(cb);
 }
@@ -711,7 +713,7 @@ function fetch_and_render_frame() {
 function load_file(file) {
   $.ajax({
     type: 'POST',
-    url: `${document.location.origin}/load/${file}`,
+    url: `${document.location.origin}/load/${inputBucket}/${file}`,
     success: function (payload) {
       numFrames = payload.numFrames;
       scale = payload.screen_scale;
@@ -872,6 +874,9 @@ function action(action, info, frame = current_frame) {
 }
 
 function startCaliban(filename, settings) {
+  inputBucket = settings.input_bucket;
+  outputBucket = settings.output_bucket;
+  
   // disable scrolling from scrolling around on page (it should just control brightness)
   document.addEventListener('wheel', function(event) {
     event.preventDefault();

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -873,7 +873,7 @@ function action(action, info, frame = current_frame) {
   });
 }
 
-function startCaliban(filename, settings) {
+function startCaliban(settings) {
   inputBucket = settings.input_bucket;
   outputBucket = settings.output_bucket;
   
@@ -892,7 +892,7 @@ function startCaliban(filename, settings) {
     }
   });
 
-  load_file(filename);
+  load_file(settings.filename);
   prepare_canvas();
 
   brush = new Brush(scale=scale, height=dimensions[1], width=dimensions[0], pad = padding);

--- a/browser/static/js/main_track.js
+++ b/browser/static/js/main_track.js
@@ -840,7 +840,7 @@ function prepare_canvas() {
 function action(action, info, frame = current_frame) {
   $.ajax({
     type:'POST',
-    url:`${document.location.origin}/action/${project_id}/${action}/${frame}`,
+    url:`${document.location.origin}/edit/${project_id}/${action}/${frame}`,
     data: info,
     success: function (payload) {
       if (payload.error) {

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -682,7 +682,7 @@ const _calculateMaxHeight = () => {
 function upload_file(cb) {
   $.ajax({
     type: 'POST',
-    url: `${document.location.origin}/upload_file/${project_id}?output-bucket=${outputBucket}`,
+    url: `${document.location.origin}/upload_file/${outputBucket}/${project_id}`,
     async: true
   }).done(cb);
 }
@@ -830,7 +830,7 @@ function render_image_display() {
 function loadFile(file, rgb = false, cb) {
   $.ajax({
     type: 'POST',
-    url: `${document.location.origin}/load/${file}?input-bucket=${inputBucket}&rgb=${rgb}`,
+    url: `${document.location.origin}/load/${inputBucket}/${file}?rgb=${rgb}`,
     async: true
   }).done(cb);
 }

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -581,6 +581,8 @@ const padding = 5;
 const maxLabelsMap = new Map();
 
 let rgb;
+let inputBucket;
+let outputBucket;
 
 var rendering_raw = false;
 var display_labels;
@@ -680,7 +682,7 @@ const _calculateMaxHeight = () => {
 function upload_file(cb) {
   $.ajax({
     type: 'POST',
-    url: `${document.location.origin}/upload_file/${project_id}`,
+    url: `${document.location.origin}/upload_file/${project_id}?output-bucket=${outputBucket}`,
     async: true
   }).done(cb);
 }
@@ -828,7 +830,7 @@ function render_image_display() {
 function loadFile(file, rgb = false, cb) {
   $.ajax({
     type: 'POST',
-    url: `${document.location.origin}/load/${file}?&rgb=${rgb}`,
+    url: `${document.location.origin}/load/${file}?input-bucket=${inputBucket}&rgb=${rgb}`,
     async: true
   }).done(cb);
 }
@@ -1029,6 +1031,8 @@ function displayUndoRedo() {
 }
 
 function startCaliban(filename, settings) {
+  inputBucket = settings.input_bucket;
+  outputBucket = settings.output_bucket;
   rgb = settings.rgb;
   display_labels = !settings.rgb;
   edit_mode = (settings.pixel_only && !settings.label_only);

--- a/browser/static/js/main_zstack.js
+++ b/browser/static/js/main_zstack.js
@@ -1030,7 +1030,7 @@ function displayUndoRedo() {
   redoButton.style.width = canvasElement.width / 2 + 'px';
 }
 
-function startCaliban(filename, settings) {
+function startCaliban(settings) {
   inputBucket = settings.input_bucket;
   outputBucket = settings.output_bucket;
   rgb = settings.rgb;
@@ -1053,7 +1053,7 @@ function startCaliban(filename, settings) {
     }
   });
 
-  loadFile(filename, settings.rgb, (payload) => {
+  loadFile(settings.filename, settings.rgb, (payload) => {
     numFrames = payload.numFrames;
     numFeatures = payload.numFeatures;
     numChannels = payload.numChannels;

--- a/browser/templates/tool.html
+++ b/browser/templates/tool.html
@@ -12,7 +12,7 @@
 
     <div id="table-col" class="col s5">
 
-      <h4>{{ title | title }}</h4>
+      <h4>{{ settings['title'] | title }}</h4>
       <p>Filename will be given after submit button is pressed.</p>
 
       <div class="row">
@@ -32,15 +32,15 @@
       <div class="row hide" id="output">
         <div class="col s12">
           <p>Filename to COPY/PASTE:</p>
-          <blockquote>{{ filename }}</blockquote>
+          <blockquote>{{ settings['filename'] }}</blockquote>
         </div>
       </div>
 
       <div class="row">
         <div class="col s12">
-          {%- if filetype == "zstack" -%}
+          {%- if settings['filetype'] == "zstack" -%}
             {% include "partials/zstack_table.html" %}
-          {%- elif filetype == "track" -%}
+          {%- elif settings['filetype'] == "track" -%}
             {% include "partials/track_table.html" %}
           {%- endif -%}
         </div>
@@ -71,10 +71,10 @@
 {%- endblock -%}
 
 {%- block extraJs -%}
-{%- if filetype == "zstack" -%}
+{%- if settings['filetype'] == "zstack" -%}
   <script type="text/javascript" src="{{ url_for('static', filename='js/main_zstack.js') }}"></script>
   <script type="text/javascript" src="{{ url_for('static', filename='js/actions.js') }}"></script>
-{%- elif filetype == "track" -%}
+{%- elif settings['filetype'] == "track" -%}
   <script type="text/javascript" src="{{ url_for('static', filename='js/main_track.js') }}"></script>
 {%- endif -%}
 
@@ -91,7 +91,7 @@
       document.getElementById("output").classList.remove("hide");
     });
   }
-  startCaliban("{{filename}}", settings);
+  startCaliban(settings);
 </script>
 <!-- END CALIBAN FUNCTION CALL -->
 {%- endblock -%}


### PR DESCRIPTION
## What
This PR adds the schema changes needed by the file-loader PR #214  to the master branch without functionality of #214. The schema changes all affect the Projects table and include:

- using only a `path` column instead of both a `filename` and a `path` column
- remove the `output_bucket` column
- add a `token` column that gives Projects a unique 12 character base64 identifier
- add a `source` column that records where a project was loaded from (currently always `s3`)

In line with these schema changes, we also change:

- the internal `load` and `upload_file` routes now include a `bucket` component like `/load/<bucket>/<projectID>`
- the `create` function and Project constructor now only have two arguments, `path` and `bucket`, instead of `filename`, `path`, `input_bucket`, and `output_bucket`.
- the tool and shortcut routes now share a `make_settings` helper function to prepare the settings dictionary sent to `tool.html`
- the settings dictionary now includes `input_bucket`, `output_bucket`, `filename`, `filetype`, and `title`. The first two are new, and the last three previously were passed alone to `tool.html`

Here is a EB deployment to test these changes: [http://bridge-test.q2qqtvkafv.us-east-2.elasticbeanstalk.com/](http://bridge-test.q2qqtvkafv.us-east-2.elasticbeanstalk.com/). This deployment is sharing a database with the current file-loader deployment to confirm that their schemas are compatible.


## Why
Both  #212 and #214 introduces changes to the database schema. #212 has been merged in and provides performance and usability improvements, so we want to deploy these features as soon as possible. However, #214 is still under development and review. If we were to deploy #212 with no changes, we would have the migrate the database to deploy #214, but with these additional changes, we have the minimum support needed to merge and deploy #214 with no migration.