### PR TITLE
Fix action history initialization to change frames correctly

### DIFF
--- a/browser/static/js/history.js
+++ b/browser/static/js/history.js
@@ -115,7 +115,8 @@ class History{
       for (let frame of actionFrames) {
         // Display unedited frame before loading edited frame
         if (frame != prevFrame) {
-          let action = new ChangeFrame(mode, frame, prevFrame);
+          let action = new ChangeFrame(mode, frame);
+          action.oldValue = prevFrame;
           this.undoStack.push(action);
           this.addFence();
           prevFrame = frame;
@@ -126,7 +127,8 @@ class History{
       }
       // Change to final project frame
       if (prevFrame != current_frame) {
-        let action = new ChangeFrame(mode, current_frame, prevFrame);
+        let action = new ChangeFrame(mode, current_frame);
+        action.oldValue = prevFrame;
         this.undoStack.push(action);
         this.addFence();
       }


### PR DESCRIPTION
## What
This is a quick bug fix that affects reloading the action history when revisiting a project URL. The constructor for a ChangeFrame action changed between #212 and #214, but did not change in initializeActionHistory, causing the frames to not change while undoing past actions after reloading the page.

One issue highlighted by this fix is that initializeActionHistory does not switch between features when past actions occurred on different features. I made an issue #220 to document this.

## Why
When actions occur on different frames, we should switch to the frame where the action occurs before undoing it so that the changes are visible.