### PR TITLE
Bebi 205 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Press <kbd>Shift</kbd> + <kbd>F</kbd> to view the previous feature.
 
 ### Adjusting the Canvas
 
-DeepCell Label can adjust how to dispaly labels and images.
+DeepCell Label can adjust how to display labels and images.
 With these changes, we can make out finer details while labeling.
 
 Scroll on the canvas to change brightness.

--- a/deepcell_label/src/controller.js
+++ b/deepcell_label/src/controller.js
@@ -110,6 +110,7 @@ export class Controller {
     } else if ((event.ctrlKey || event.metaKey) && (event.key === 'Z' || event.key === 'z')) {
       this.undo();
     } else if ((event.ctrlKey || event.metaKey) && event.key === 'b') {
+      event.preventDefault();
       this.service.send('TOGGLERGB');
     } else if (keydownLookup[event.key]) {
       this.service.send(keydownLookup[event.key]);

--- a/deepcell_label/src/controller.js
+++ b/deepcell_label/src/controller.js
@@ -17,7 +17,10 @@ export class Controller {
     const labelMachine = createLabelMachine(projectID);
     this.service = interpret(labelMachine); // , { devTools: true });
     // add a listener to update the info table whenever a transition occurs
-    this.service.onTransition(() => { window.model?.notifyInfoChange() });
+    this.service.onTransition(() => {
+      window.model?.notifyInfoChange();
+      window.model?.notifyImageChange();
+    });
     // Start the service
     this.service.start();
     window.service = this.service;

--- a/deepcell_label/src/statechart.js
+++ b/deepcell_label/src/statechart.js
@@ -640,9 +640,9 @@ const createLabelMachine = (projectID) => {
         decrementFrame: () => addFencedAction(new ChangeFrame(window.model.frame - 1)),
         incrementFrame: () => addFencedAction(new ChangeFrame(window.model.frame + 1)),
         decrementChannel: () => addFencedAction(new ChangeChannel(window.model.channel - 1)),
-        incrementChannel: () => addFencedAction(new ChangeChannel(window.model.channel - 1)),
+        incrementChannel: () => addFencedAction(new ChangeChannel(window.model.channel + 1)),
         decrementFeature: () => addFencedAction(new ChangeFeature(window.model.feature - 1)),
-        incrementFeature: () => addFencedAction(new ChangeFeature(window.model.feature - 1)),
+        incrementFeature: () => addFencedAction(new ChangeFeature(window.model.feature + 1)),
         // adjuster actions
         changeContrast: (_, event) => addAction(new ChangeContrast(event.change)),
         changeBrightness: (_, event) => addAction(new ChangeBrightness(event.change)),

--- a/deepcell_label/templates/partials/infopane.html
+++ b/deepcell_label/templates/partials/infopane.html
@@ -101,7 +101,7 @@
             <h4>The Canvas</h4>
             
             <p dir="ltr">
-              The right-side canvas shows an images and labels.
+              The right-side canvas shows images and labels.
               Each label has a different color overlaid on the raw image.
             </p>
 
@@ -148,7 +148,7 @@
             <h5>Adjusting the Canvas</h5>
             
             <p dir="ltr">
-              DeepCell Label can adjust how to dispaly labels and images.
+              DeepCell Label can adjust how to display labels and images.
               With these changes, we can make out finer details while labeling.
             </p>
             

--- a/deepcell_label/templates/partials/infopane.html
+++ b/deepcell_label/templates/partials/infopane.html
@@ -104,6 +104,12 @@
               The right-side canvas shows an images and labels.
               Each label has a different color overlaid on the raw image.
             </p>
+
+            <p dir="ltr">
+              The borders of the canvas help show where we are within an image. 
+              If a border is white, we are along an edge of the image. 
+              If a border is black, the image extends off-canvas in that direction and we can pan or zoom out to view it.
+            </p>
             
             <h5>Navigating the Canvas</h5>
             
@@ -147,19 +153,28 @@
             </p>
             
             <p dir="ltr">
-              <strong>Scroll</strong> on the canvas to change brightness.
+              <strong>Scroll</strong> on the canvas to change brightness. Brightness makes the whole image lighter or darker.
               <br>
-              <strong>Hold <kbd>Shift</kbd> and scroll</strong> on the canvas to change the contrast.
+              <strong>Hold <kbd>Shift</kbd> and scroll</strong> on the canvas to change the contrast. Increasing contrast improves the visibility of objects in the raw image.
               <br>
               Press <kbd>0</kbd> to reset the brightness and contrast.
+              <br>
+              Each channel adjusts its brightness and contrast separately.
             </p>
             
             <p dir="ltr">
               Press <kbd>Z</kbd> to toggle between viewing the label overlay, the labels only, and the raw image only.
             </p>
+
+            <p dir="ltr">
+              Press <kbd>I</kbd> to invert the raw image. 
+              Inverting the raw image helps to see objects under the label overlay. 
+              We can only invert the image when viewing label overlay.
+            </p>
             
             <p dir="ltr">
-              Press <kbd>H</kbd> to toggle highlighting the brush label in red.
+              Press <kbd>H</kbd> to toggle highlighting. 
+              Highlighting makes the foreground label bright red and helps to see which label we are editing.
             </p>
           </div>
           <div id="tab4" class="col s12">


### PR DESCRIPTION
## What

Fixes some typos & adds some excerpts from previous workshop material to the dropdown documentation.

Two functional changes:

- prevent default behavior for Ctrl+B (which is a bookmark shortcut in Firefox)
- rerender the canvas on state transitions so the brush appears immediately when switching to the brush tool

## Why

Trying to get in some last-minute polish before the Label workshop later today.