### PR TITLE
Upload fix

### DIFF
--- a/deepcell_label/blueprints.py
+++ b/deepcell_label/blueprints.py
@@ -308,7 +308,7 @@ def upload_project_to_s3(bucket, token):
     exporter = exporters.S3Exporter(project)
     exporter.export(bucket)
     # add "finished" timestamp and null out PickleType columns
-    project.finish()
+    # project.finish()
 
     current_app.logger.debug('Uploaded %s to S3 bucket %s from project %s in %s s.',
                              project.path, bucket, token,

--- a/deepcell_label/templates/tool.html
+++ b/deepcell_label/templates/tool.html
@@ -76,7 +76,7 @@
       // disable button and show loading bar
       document.getElementById('submit').classList.add('disabled');
       document.getElementById('loading-bar').classList.add('active');
-      const upload = fetch(`${document.location.origin}/upload_file/${outputBucket}/${projectID}`,
+      const upload = fetch(`${document.location.origin}/api/upload/${outputBucket}/${projectID}`,
         { method: 'POST' }
       );
       upload.then(() => {


### PR DESCRIPTION
These are hotfixes for submitting jobs from Anolytics to call the correct route and avoid finishing projects so that project URLs remaining usable for QC.