### PR TITLE
Update named parameters for `replace_with_parent`.

### DIFF
--- a/visualizer/src/service/tools/toolMachine.js
+++ b/visualizer/src/service/tools/toolMachine.js
@@ -36,7 +36,7 @@ const toolMachine = Machine(
     },
     on: {
       SAVE: { actions: 'save' },
-      RESTORE: { target: '.checkTool', actions: 'restore' },
+      RESTORE: { target: '.checkTool', actions: ['restore', respond('RESTORED')] },
 
       SEGMENT: { target: '.checkTool', actions: assign({ tool: 'segment' }) },
       TRACK: { target: '.checkTool', actions: assign({ tool: 'track' }) },

--- a/visualizer/src/service/tools/trackMachine.js
+++ b/visualizer/src/service/tools/trackMachine.js
@@ -74,8 +74,7 @@ const trackMachine = Machine(
         type: 'EDIT',
         action: 'replace_with_parent',
         args: {
-          label_1: parent,
-          label_2: daughter,
+          daughter: daughter,
         },
       })),
       createNewCell: sendParent((_, { label }) => ({


### PR DESCRIPTION
## What
* Change the named arguments for `replace_with_parent` from the old `label_1`/`label_2` to just `daughter`.

## Why
* The backend was hitting 500 errors due to named argument errors.
