### PR TITLE
Update swap and replace hotkeys

### DIFF
--- a/visualizer/src/Controls/Segment/ActionButtons/ReplaceButton.js
+++ b/visualizer/src/Controls/Segment/ActionButtons/ReplaceButton.js
@@ -11,7 +11,7 @@ function ReplaceButton(props) {
 
   const tooltipText = (
     <span>
-      Combines two labels (<kbd>R</kbd>)
+      Combines two labels (<kbd>Shift</kbd> + <kbd>R</kbd>)
     </span>
   );
 
@@ -20,7 +20,7 @@ function ReplaceButton(props) {
       {...rest}
       tooltipText={tooltipText}
       onClick={onClick}
-      hotkey='r'
+      hotkey='shift+r'
       className={`${className} ${styles.button}`}
     >
       Replace

--- a/visualizer/src/Controls/Segment/ActionButtons/SwapButton.js
+++ b/visualizer/src/Controls/Segment/ActionButtons/SwapButton.js
@@ -11,7 +11,7 @@ function SwapButton(props) {
 
   const tooltipText = (
     <span>
-      Switches the position of two labels (<kbd>S</kbd>)
+      Switches the position of two labels (<kbd>Shift</kbd> + <kbd>S</kbd>)
     </span>
   );
 
@@ -20,7 +20,7 @@ function SwapButton(props) {
       {...rest}
       tooltipText={tooltipText}
       onClick={onClick}
-      hotkey='s'
+      hotkey='shift+s'
       className={`${className} ${styles.button}`}
     >
       Swap


### PR DESCRIPTION
Swap and replace can cause drastic changes to the labeling, in particular filling all the unlabeled areas when swapping or replacing the `0` label. Changing the hotkeys from S to Shift + S and R to Shift + R makes these actions harder to accidentally do.
