### PR TITLE
Track selected labels for undo/redo

### DIFF
--- a/visualizer/src/service/projectMachine.js
+++ b/visualizer/src/service/projectMachine.js
@@ -115,11 +115,12 @@ const createProjectMachine = (projectId, bucket) =>
           undoRef: () => spawn(undoMachine, 'undo'),
         }),
         addActorsToUndo: pure(context => {
-          const { canvasRef, segmentRef, imageRef } = context;
+          const { canvasRef, segmentRef, imageRef, selectRef } = context;
           return [
             send({ type: 'ADD_ACTOR', actor: canvasRef }, { to: 'undo' }),
             send({ type: 'ADD_ACTOR', actor: imageRef }, { to: 'undo' }),
             send({ type: 'ADD_ACTOR', actor: segmentRef }, { to: 'undo' }),
+            send({ type: 'ADD_ACTOR', actor: selectRef }, { to: 'undo' }),
           ];
         }),
         sendProject: pure((context, event) => {

--- a/visualizer/src/service/selectMachine.js
+++ b/visualizer/src/service/selectMachine.js
@@ -1,4 +1,5 @@
 import { actions, assign, Machine, send, sendParent } from 'xstate';
+import { respond } from 'xstate/lib/actions';
 
 const { pure } = actions;
 
@@ -136,6 +137,8 @@ const selectMachine = Machine(
       NEXT_FOREGROUND: { actions: 'nextForeground' },
       PREV_BACKGROUND: { actions: 'prevBackground' },
       NEXT_BACKGROUND: { actions: 'nextBackground' },
+      SAVE: { actions: 'save' },
+      RESTORE: { actions: 'restore' },
     },
   },
   {
@@ -148,6 +151,12 @@ const selectMachine = Machine(
       ...selectShortcutActions,
       ...cycleActions,
       ...setActions,
+      save: respond(({ foreground, background }) => ({ type: 'RESTORE', foreground, background })),
+      restore: pure((_, { foreground, background }) => [
+        respond('RESTORED'),
+        send({ type: 'FOREGROUND', foreground }),
+        send({ type: 'BACKGROUND', background }),
+      ]),
     },
   }
 );


### PR DESCRIPTION
I noticed when debugging Anolytic's issue this morning with not being able to make new labels that the selected labels were not changing when undoing and redoing. The segmentMachine used to manage the selected labels, so they were undone and redone through this machine, so it looks like we never added the selectMachine to the undo/redo history.