### PR TITLE
Fix tool keybinds

### DIFF
--- a/visualizer/src/Canvas/Tool/BrushCanvas.js
+++ b/visualizer/src/Canvas/Tool/BrushCanvas.js
@@ -1,6 +1,6 @@
 import { useSelector } from '@xstate/react';
 import React, { useEffect, useMemo, useRef } from 'react';
-import { useCanvas, useSelect, useTool } from '../../ProjectContext';
+import { useBrush, useCanvas, useSelect } from '../../ProjectContext';
 import { drawBrush, drawTrace } from '../canvasUtils';
 
 const BrushCanvas = ({ className }) => {
@@ -20,7 +20,7 @@ const BrushCanvas = ({ className }) => {
   const erasing = background !== 0;
   const brushColor = useMemo(() => (erasing ? [255, 0, 0, 255] : [255, 255, 255, 255]), [erasing]);
 
-  const brush = useTool();
+  const brush = useBrush();
   const x = useSelector(brush, state => state.context.x);
   const y = useSelector(brush, state => state.context.y);
   const trace = useSelector(brush, state => state.context.trace);

--- a/visualizer/src/Canvas/Tool/ThresholdCanvas.js
+++ b/visualizer/src/Canvas/Tool/ThresholdCanvas.js
@@ -1,6 +1,6 @@
 import { useSelector } from '@xstate/react';
 import React, { useEffect, useRef } from 'react';
-import { useCanvas, useTool } from '../../ProjectContext';
+import { useCanvas, useThreshold } from '../../ProjectContext';
 import { drawBox } from '../canvasUtils';
 
 const ThresholdCanvas = ({ className }) => {
@@ -15,7 +15,7 @@ const ThresholdCanvas = ({ className }) => {
   const width = sw * scale * window.devicePixelRatio;
   const height = sh * scale * window.devicePixelRatio;
 
-  const threshold = useTool();
+  const threshold = useThreshold();
   const x1 = useSelector(threshold, state => state.context.x);
   const y1 = useSelector(threshold, state => state.context.y);
   const [x2, y2] = useSelector(threshold, state => state.context.firstPoint);

--- a/visualizer/src/Controls/Segment/ActionButtons/AutofitButton.js
+++ b/visualizer/src/Controls/Segment/ActionButtons/AutofitButton.js
@@ -20,6 +20,7 @@ function AutofitButton(props) {
   return (
     <ActionButton
       {...rest}
+      disabled={!grayscale}
       tooltipText={grayscale ? tooltipText : 'Requires a single channel'}
       onClick={onClick}
       hotkey='m'

--- a/visualizer/src/Controls/Segment/ActionButtons/AutofitButton.js
+++ b/visualizer/src/Controls/Segment/ActionButtons/AutofitButton.js
@@ -7,7 +7,7 @@ function AutofitButton(props) {
   const { className, ...rest } = props;
   const styles = useStyles();
   const segment = useSegment();
-  const grayscale = useSelector(segment, state => state.matches('colorMode.grayscale'));
+  const grayscale = useSelector(segment, state => state.matches('display.grayscale'));
 
   const onClick = useCallback(() => segment.send('AUTOFIT'), [segment]);
 

--- a/visualizer/src/Controls/Segment/ToolButtons/BrushButton.js
+++ b/visualizer/src/Controls/Segment/ToolButtons/BrushButton.js
@@ -12,7 +12,7 @@ function BrushButton(props) {
   const foreground = useSelector(select, state => state.context.foreground);
 
   const onClick = useCallback(() => {
-    segment.send('USE_BRUSH');
+    segment.send({ type: 'SET_TOOL', tool: 'brush' });
     selected
       ? select.send({ type: 'FOREGROUND', foreground: selected })
       : select.send({ type: 'NEW_FOREGROUND' });

--- a/visualizer/src/Controls/Segment/ToolButtons/EraserButton.js
+++ b/visualizer/src/Controls/Segment/ToolButtons/EraserButton.js
@@ -12,7 +12,7 @@ function EraserButton(props) {
   const background = useSelector(select, state => state.context.background);
 
   const onClick = useCallback(() => {
-    segment.send('USE_BRUSH');
+    segment.send({ type: 'SET_TOOL', tool: 'brush' });
     select.send({ type: 'FOREGROUND', foreground: 0 });
     select.send({ type: 'BACKGROUND', background: selected });
   }, [segment, select, selected]);

--- a/visualizer/src/Controls/Segment/ToolButtons/FloodButton.js
+++ b/visualizer/src/Controls/Segment/ToolButtons/FloodButton.js
@@ -7,7 +7,7 @@ function FloodButton(props) {
   const segment = useSegment();
   const tool = useSelector(segment, state => state.context.tool);
 
-  const onClick = useCallback(() => segment.send('USE_FLOOD'), [segment]);
+  const onClick = useCallback(() => segment.send({ type: 'SET_TOOL', tool: 'flood' }), [segment]);
 
   const tooltipText = (
     <span>

--- a/visualizer/src/Controls/Segment/ToolButtons/SelectButton.js
+++ b/visualizer/src/Controls/Segment/ToolButtons/SelectButton.js
@@ -7,7 +7,7 @@ function SelectButton(props) {
   const segment = useSegment();
   const tool = useSelector(segment, state => state.context.tool);
 
-  const onClick = useCallback(() => segment.send('USE_SELECT'), [segment]);
+  const onClick = useCallback(() => segment.send({ type: 'SET_TOOL', tool: 'select' }), [segment]);
 
   const tooltipText = (
     <span>

--- a/visualizer/src/Controls/Segment/ToolButtons/ThresholdButton.js
+++ b/visualizer/src/Controls/Segment/ToolButtons/ThresholdButton.js
@@ -8,7 +8,10 @@ function ThresholdButton(props) {
   const tool = useSelector(segment, state => state.context.tool);
   const grayscale = useSelector(segment, state => state.matches('colorMode.grayscale'));
 
-  const onClick = useCallback(() => segment.send('USE_THRESHOLD'), [segment]);
+  const onClick = useCallback(
+    () => segment.send({ type: 'SET_TOOL', tool: 'threshold' }),
+    [segment]
+  );
 
   const tooltipText = grayscale ? (
     <span>

--- a/visualizer/src/Controls/Segment/ToolButtons/ThresholdButton.js
+++ b/visualizer/src/Controls/Segment/ToolButtons/ThresholdButton.js
@@ -6,7 +6,7 @@ import ToolButton from './ToolButton';
 function ThresholdButton(props) {
   const segment = useSegment();
   const tool = useSelector(segment, state => state.context.tool);
-  const grayscale = useSelector(segment, state => state.matches('colorMode.grayscale'));
+  const grayscale = useSelector(segment, state => state.matches('display.grayscale'));
 
   const onClick = useCallback(
     () => segment.send({ type: 'SET_TOOL', tool: 'threshold' }),

--- a/visualizer/src/Controls/Segment/ToolButtons/TrimButton.js
+++ b/visualizer/src/Controls/Segment/ToolButtons/TrimButton.js
@@ -7,7 +7,7 @@ function TrimButton(props) {
   const segment = useSegment();
   const tool = useSelector(segment, state => state.context.tool);
 
-  const onClick = useCallback(() => segment.send('USE_TRIM'), [segment]);
+  const onClick = useCallback(() => segment.send({ type: 'SET_TOOL', tool: 'trim' }), [segment]);
 
   const tooltipText = (
     <span>

--- a/visualizer/src/Controls/Segment/ToolButtons/WatershedButton.js
+++ b/visualizer/src/Controls/Segment/ToolButtons/WatershedButton.js
@@ -8,7 +8,10 @@ function WatershedButton(props) {
   const tool = useSelector(segment, state => state.context.tool);
   const grayscale = useSelector(segment, state => state.matches('colorMode.grayscale'));
 
-  const onClick = useCallback(() => segment.send('USE_WATERSHED'), [segment]);
+  const onClick = useCallback(
+    () => segment.send({ type: 'SET_TOOL', tool: 'watershed' }),
+    [segment]
+  );
 
   const tooltipText = grayscale ? (
     <span>

--- a/visualizer/src/Controls/Segment/ToolButtons/WatershedButton.js
+++ b/visualizer/src/Controls/Segment/ToolButtons/WatershedButton.js
@@ -6,7 +6,7 @@ import ToolButton from './ToolButton';
 function WatershedButton(props) {
   const segment = useSegment();
   const tool = useSelector(segment, state => state.context.tool);
-  const grayscale = useSelector(segment, state => state.matches('colorMode.grayscale'));
+  const grayscale = useSelector(segment, state => state.matches('display.grayscale'));
 
   const onClick = useCallback(
     () => segment.send({ type: 'SET_TOOL', tool: 'watershed' }),

--- a/visualizer/src/ProjectContext.js
+++ b/visualizer/src/ProjectContext.js
@@ -133,12 +133,22 @@ export function useSegment() {
   return segment;
 }
 
-export function useTool() {
+export function useBrush() {
   const project = useProject();
   const tool = useSelector(project, state => {
     const segment = state.context.segmentRef;
-    const tool = segment.state.context.toolActor;
-    return tool;
+    const tools = segment.state.context.tools;
+    return tools.brush;
+  });
+  return tool;
+}
+
+export function useThreshold() {
+  const project = useProject();
+  const tool = useSelector(project, state => {
+    const segment = state.context.segmentRef;
+    const tools = segment.state.context.tools;
+    return tools.threshold;
   });
   return tool;
 }

--- a/visualizer/src/service/canvasMachine.js
+++ b/visualizer/src/service/canvasMachine.js
@@ -136,7 +136,7 @@ const canvasMachine = Machine(
         })),
       },
       RESTORE: { actions: ['restore', respond('RESTORED')] },
-      LABELED_ARRAY: { actions: ['setLabeledArray', 'sendLabel'] },
+      LABELED_ARRAY: { actions: ['setLabeledArray', 'sendHovering'] },
       COORDINATES: {
         cond: 'newCoordinates',
         actions: ['setCoordinates', 'sendHovering', 'sendParent'],

--- a/visualizer/src/service/canvasMachine.js
+++ b/visualizer/src/service/canvasMachine.js
@@ -228,7 +228,7 @@ const canvasMachine = Machine(
       setLabel: assign((_, { label }) => ({ label })),
       sendLabel: send(({ labeledArray: array, x, y }) => ({
         type: 'LABEL',
-        label: array ? Math.abs(array[y][x]) : 0,
+        label: array && x !== null && y !== null ? Math.abs(array[y][x]) : null,
       })),
       setDimensions: assign({
         availableWidth: (_, { width }) => width,

--- a/visualizer/src/service/canvasMachine.js
+++ b/visualizer/src/service/canvasMachine.js
@@ -1,6 +1,6 @@
 // Manages zooming, panning, and interacting with the canvas
-// Interactions sent as LABEL, COORDINATES, mousedown, and mouseup events to parent
-// LABEL event sent when the label below the cursor changes
+// Interactions sent as HOVERING, COORDINATES, mousedown, and mouseup events to parent
+// HOVERING event sent when the label below the cursor changes
 // COORDINATES event sent when the pixel below the cursor changes
 
 // Panning interface:
@@ -118,7 +118,7 @@ const canvasMachine = Machine(
       dy: 0,
       // label data
       labeledArray: null,
-      label: null,
+      hovering: null,
       panOnDrag: true,
     },
     invoke: [{ src: 'listenForMouseUp' }, { src: 'listenForZoomHotkeys' }],
@@ -139,11 +139,11 @@ const canvasMachine = Machine(
       LABELED_ARRAY: { actions: ['setLabeledArray', 'sendLabel'] },
       COORDINATES: {
         cond: 'newCoordinates',
-        actions: ['setCoordinates', 'sendLabel', 'sendParent'],
+        actions: ['setCoordinates', 'sendHovering', 'sendParent'],
       },
-      LABEL: {
-        cond: 'newLabel',
-        actions: ['setLabel', 'sendParent'],
+      HOVERING: {
+        cond: 'newHovering',
+        actions: ['setHovering', 'sendParent'],
       },
     },
     initial: 'idle',
@@ -205,7 +205,7 @@ const canvasMachine = Machine(
     },
     guards: {
       newCoordinates: (context, event) => context.x !== event.y || context.y !== event.y,
-      newLabel: (context, event) => context.label !== event.label,
+      newHovering: (context, event) => context.hovering !== event.hovering,
       moved: ({ dx, dy }) => Math.abs(dx) > 10 || Math.abs(dy) > 10,
       panOnDrag: ({ panOnDrag }) => panOnDrag,
     },
@@ -225,10 +225,10 @@ const canvasMachine = Machine(
         y = Math.max(0, Math.min(y, height - 1));
         return { type: 'COORDINATES', x, y };
       }),
-      setLabel: assign((_, { label }) => ({ label })),
-      sendLabel: send(({ labeledArray: array, x, y }) => ({
-        type: 'LABEL',
-        label: array && x !== null && y !== null ? Math.abs(array[y][x]) : null,
+      setHovering: assign((_, { hovering }) => ({ hovering })),
+      sendHovering: send(({ labeledArray: array, x, y }) => ({
+        type: 'HOVERING',
+        hovering: array && x !== null && y !== null ? Math.abs(array[y][x]) : null,
       })),
       setDimensions: assign({
         availableWidth: (_, { width }) => width,

--- a/visualizer/src/service/canvasMachine.js
+++ b/visualizer/src/service/canvasMachine.js
@@ -111,8 +111,8 @@ const canvasMachine = Machine(
       sx: 0,
       sy: 0,
       // position of cursor within image
-      x: 0,
-      y: 0,
+      x: null,
+      y: null,
       // how much the canvas has moved in the current pan
       dx: 0,
       dy: 0,

--- a/visualizer/src/service/projectMachine.js
+++ b/visualizer/src/service/projectMachine.js
@@ -79,9 +79,7 @@ const createProjectMachine = (projectId, bucket) =>
         },
 
         // from canvas
-        LABEL: {
-          actions: [forwardTo('segment'), forwardTo('select')],
-        },
+        HOVERING: { actions: [forwardTo('segment'), forwardTo('select')] },
         COORDINATES: { actions: forwardTo('segment') },
         FOREGROUND: { actions: [forwardTo('segment')] },
         BACKGROUND: { actions: [forwardTo('segment')] },

--- a/visualizer/src/service/selectMachine.js
+++ b/visualizer/src/service/selectMachine.js
@@ -95,11 +95,15 @@ const setActions = {
 const selectMachine = Machine(
   {
     id: 'select',
+    entry: [
+      send({ type: 'FOREGROUND', foreground: 1 }),
+      send({ type: 'BACKGROUND', background: 0 }),
+    ],
     context: {
-      selected: 1,
-      foreground: 1,
-      background: 0,
-      hovering: 0,
+      selected: null,
+      foreground: null,
+      background: null,
+      hovering: null,
       labels: {},
     },
     on: {

--- a/visualizer/src/service/selectMachine.js
+++ b/visualizer/src/service/selectMachine.js
@@ -85,7 +85,7 @@ const cycleActions = {
 };
 
 const setActions = {
-  setHovering: assign({ hovering: (_, { label }) => label }),
+  setHovering: assign({ hovering: (_, { hovering }) => hovering }),
   setLabels: assign({ labels: (_, { labels }) => labels }),
   setForeground: assign({ foreground: (_, { foreground }) => foreground }),
   setBackground: assign({ background: (_, { background }) => background }),
@@ -116,7 +116,7 @@ const selectMachine = Machine(
         { actions: 'selectBackground' },
       ],
 
-      LABEL: { actions: 'setHovering' },
+      HOVERING: { actions: 'setHovering' },
       LABELS: { actions: 'setLabels' },
       SELECTED: { actions: ['setSelected', sendParent((c, e) => e)] },
       FOREGROUND: {

--- a/visualizer/src/service/tools/segment/brushMachine.js
+++ b/visualizer/src/service/tools/segment/brushMachine.js
@@ -1,87 +1,86 @@
 import { assign, Machine, sendParent } from 'xstate';
 import { toolActions, toolGuards } from './toolUtils';
 
-const createBrushMachine = () =>
-  Machine(
-    {
-      invoke: {
-        src: 'listenForBrushHotkeys',
-      },
-      context: {
-        x: null,
-        y: null,
-        foreground: null,
-        background: null,
-        trace: [],
-        brushSize: 5,
-      },
-      initial: 'idle',
-      states: {
-        idle: {
-          entry: assign({ trace: [] }),
-          on: {
-            mousedown: [{ cond: 'shift' }, { target: 'dragging', actions: 'addToTrace' }],
-          },
-        },
-        dragging: {
-          on: {
-            COORDINATES: { actions: ['setCoordinates', 'addToTrace'] },
-            mouseup: { target: 'done', actions: 'paint' },
-          },
-        },
-        // needed avoid sending empty trace in EDIT event
-        done: {
-          always: 'idle',
+const brushMachine = Machine(
+  {
+    invoke: {
+      src: 'listenForBrushHotkeys',
+    },
+    context: {
+      x: null,
+      y: null,
+      foreground: null,
+      background: null,
+      trace: [],
+      brushSize: 5,
+    },
+    initial: 'idle',
+    states: {
+      idle: {
+        entry: assign({ trace: [] }),
+        on: {
+          mousedown: [{ cond: 'shift' }, { target: 'dragging', actions: 'addToTrace' }],
         },
       },
-      on: {
-        EXIT: '.idle',
-        INCREASE_BRUSH_SIZE: { actions: 'increaseBrushSize' },
-        DECREASE_BRUSH_SIZE: { actions: 'decreaseBrushSize' },
-        COORDINATES: { actions: 'setCoordinates' },
-        FOREGROUND: { actions: 'setForeground' },
-        BACKGROUND: { actions: 'setBackground' },
+      dragging: {
+        on: {
+          COORDINATES: { actions: ['setCoordinates', 'addToTrace'] },
+          mouseup: { target: 'done', actions: 'paint' },
+        },
+      },
+      // needed avoid sending empty trace in EDIT event
+      done: {
+        always: 'idle',
       },
     },
-    {
-      services: {
-        listenForBrushHotkeys: () => send => {
-          const lookup = {
-            ArrowUp: 'INCREASE_BRUSH_SIZE',
-            ArrowDown: 'DECREASE_BRUSH_SIZE',
-          };
-          const listener = e => {
-            if (e.key in lookup) {
-              e.preventDefault();
-              send(lookup[e.key]);
-            }
-          };
-          window.addEventListener('keydown', listener);
-          return () => window.removeEventListener('keydown', listener);
+    on: {
+      EXIT: '.idle',
+      INCREASE_BRUSH_SIZE: { actions: 'increaseBrushSize' },
+      DECREASE_BRUSH_SIZE: { actions: 'decreaseBrushSize' },
+      COORDINATES: { actions: 'setCoordinates' },
+      FOREGROUND: { actions: 'setForeground' },
+      BACKGROUND: { actions: 'setBackground' },
+    },
+  },
+  {
+    services: {
+      listenForBrushHotkeys: () => send => {
+        const lookup = {
+          ArrowUp: 'INCREASE_BRUSH_SIZE',
+          ArrowDown: 'DECREASE_BRUSH_SIZE',
+        };
+        const listener = e => {
+          if (e.key in lookup) {
+            e.preventDefault();
+            send(lookup[e.key]);
+          }
+        };
+        window.addEventListener('keydown', listener);
+        return () => window.removeEventListener('keydown', listener);
+      },
+    },
+    guards: toolGuards,
+    actions: {
+      ...toolActions,
+      increaseBrushSize: assign({
+        brushSize: ({ brushSize }) => brushSize + 1,
+      }),
+      decreaseBrushSize: assign({
+        brushSize: ({ brushSize }) => Math.max(1, brushSize - 1),
+      }),
+      addToTrace: assign({ trace: ({ trace, x, y }) => [...trace, [x, y]] }),
+      paint: sendParent(context => ({
+        type: 'EDIT',
+        action: 'handle_draw',
+        args: {
+          trace: JSON.stringify(context.trace),
+          foreground: context.foreground,
+          background: context.background,
+          brush_size: context.brushSize,
         },
-      },
-      guards: toolGuards,
-      actions: {
-        ...toolActions,
-        increaseBrushSize: assign({
-          brushSize: ({ brushSize }) => brushSize + 1,
-        }),
-        decreaseBrushSize: assign({
-          brushSize: ({ brushSize }) => Math.max(1, brushSize - 1),
-        }),
-        addToTrace: assign({ trace: ({ trace, x, y }) => [...trace, [x, y]] }),
-        paint: sendParent(context => ({
-          type: 'EDIT',
-          action: 'handle_draw',
-          args: {
-            trace: JSON.stringify(context.trace),
-            foreground: context.foreground,
-            background: context.background,
-            brush_size: context.brushSize,
-          },
-        })),
-      },
-    }
-  );
+      })),
+    },
+  }
+);
 
-export default createBrushMachine;
+export default brushMachine;

--- a/visualizer/src/service/tools/segment/brushMachine.js
+++ b/visualizer/src/service/tools/segment/brushMachine.js
@@ -1,17 +1,17 @@
 import { assign, Machine, sendParent } from 'xstate';
 import { toolActions, toolGuards } from './toolUtils';
 
-const createBrushMachine = ({ x, y, foreground, background }) =>
+const createBrushMachine = () =>
   Machine(
     {
       invoke: {
         src: 'listenForBrushHotkeys',
       },
       context: {
-        x,
-        y,
-        foreground,
-        background,
+        x: null,
+        y: null,
+        foreground: null,
+        background: null,
         trace: [],
         brushSize: 5,
       },

--- a/visualizer/src/service/tools/segment/brushMachine.js
+++ b/visualizer/src/service/tools/segment/brushMachine.js
@@ -24,6 +24,7 @@ const brushMachine = Machine(
       },
       dragging: {
         on: {
+          EXIT: 'idle',
           COORDINATES: { actions: ['setCoordinates', 'addToTrace'] },
           mouseup: { target: 'done', actions: 'paint' },
         },
@@ -34,7 +35,6 @@ const brushMachine = Machine(
       },
     },
     on: {
-      EXIT: '.idle',
       INCREASE_BRUSH_SIZE: { actions: 'increaseBrushSize' },
       DECREASE_BRUSH_SIZE: { actions: 'decreaseBrushSize' },
       COORDINATES: { actions: 'setCoordinates' },

--- a/visualizer/src/service/tools/segment/brushMachine.js
+++ b/visualizer/src/service/tools/segment/brushMachine.js
@@ -35,6 +35,7 @@ const createBrushMachine = ({ x, y, foreground, background }) =>
         },
       },
       on: {
+        EXIT: '.idle',
         INCREASE_BRUSH_SIZE: { actions: 'increaseBrushSize' },
         DECREASE_BRUSH_SIZE: { actions: 'decreaseBrushSize' },
         COORDINATES: { actions: 'setCoordinates' },
@@ -77,9 +78,6 @@ const createBrushMachine = ({ x, y, foreground, background }) =>
             foreground: context.foreground,
             background: context.background,
             brush_size: context.brushSize,
-            // frame: context.frame,
-            // feature: context.feature,
-            // channel: context.channel,
           },
         })),
       },

--- a/visualizer/src/service/tools/segment/floodMachine.js
+++ b/visualizer/src/service/tools/segment/floodMachine.js
@@ -1,40 +1,39 @@
 import { Machine, sendParent } from 'xstate';
 import { toolActions, toolGuards } from './toolUtils';
 
-const createFloodMachine = () =>
-  Machine(
-    {
-      context: {
-        x: null,
-        y: null,
-        label: null,
-        foreground: null,
-        background: null,
-      },
-      on: {
-        COORDINATES: { actions: 'setCoordinates' },
-        HOVERING: { actions: 'setHovering' },
-        FOREGROUND: { actions: 'setForeground' },
-        BACKGROUND: { actions: 'setBackground' },
-        mouseup: { actions: ['flood', 'selectBackground'] },
-      },
+const floodMachine = Machine(
+  {
+    context: {
+      x: null,
+      y: null,
+      label: null,
+      foreground: null,
+      background: null,
     },
-    {
-      guards: toolGuards,
-      actions: {
-        ...toolActions,
-        selectBackground: sendParent('SELECT_BACKGROUND'),
-        flood: sendParent(({ foreground, x, y }, event) => ({
-          type: 'EDIT',
-          action: 'flood',
-          args: {
-            label: foreground,
-            x_location: x,
-            y_location: y,
-          },
-        })),
-      },
-    }
-  );
+    on: {
+      COORDINATES: { actions: 'setCoordinates' },
+      HOVERING: { actions: 'setHovering' },
+      FOREGROUND: { actions: 'setForeground' },
+      BACKGROUND: { actions: 'setBackground' },
+      mouseup: { actions: ['flood', 'selectBackground'] },
+    },
+  },
+  {
+    guards: toolGuards,
+    actions: {
+      ...toolActions,
+      selectBackground: sendParent('SELECT_BACKGROUND'),
+      flood: sendParent(({ foreground, x, y }, event) => ({
+        type: 'EDIT',
+        action: 'flood',
+        args: {
+          label: foreground,
+          x_location: x,
+          y_location: y,
+        },
+      })),
+    },
+  }
+);
 
-export default createFloodMachine;
+export default floodMachine;

--- a/visualizer/src/service/tools/segment/floodMachine.js
+++ b/visualizer/src/service/tools/segment/floodMachine.js
@@ -1,22 +1,22 @@
 import { Machine, sendParent } from 'xstate';
 import { toolActions, toolGuards } from './toolUtils';
 
-const createFloodMachine = ({ x, y, label, foreground, background }) =>
+const createFloodMachine = () =>
   Machine(
     {
       context: {
-        x,
-        y,
-        label,
-        foreground,
-        background,
+        x: null,
+        y: null,
+        label: null,
+        foreground: null,
+        background: null,
       },
       on: {
         COORDINATES: { actions: 'setCoordinates' },
-        LABEL: { actions: 'setLabel' },
+        HOVERING: { actions: 'setHovering' },
         FOREGROUND: { actions: 'setForeground' },
         BACKGROUND: { actions: 'setBackground' },
-        mouseup: [{ cond: 'onBackground', actions: 'flood' }, { actions: 'selectBackground' }],
+        mouseup: { actions: ['flood', 'selectBackground'] },
       },
     },
     {

--- a/visualizer/src/service/tools/segment/selectMachine.js
+++ b/visualizer/src/service/tools/segment/selectMachine.js
@@ -1,37 +1,36 @@
 import { Machine, sendParent } from 'xstate';
 import { toolActions, toolGuards } from './toolUtils';
 
-const createSelectMachine = () =>
-  Machine(
-    {
-      context: {
-        hovering: null,
-        foreground: null,
-        background: null,
-      },
-      on: {
-        FOREGROUND: { actions: 'setForeground' },
-        BACKGROUND: { actions: 'setBackground' },
-        HOVERING: { actions: 'setHovering' },
-        mouseup: [
-          {
-            cond: 'doubleClick',
-            actions: ['resetForeground', 'selectBackground'],
-          },
-          { cond: 'onForeground', actions: 'selectBackground' },
-          { actions: 'selectForeground' },
-        ],
-      },
+const selectMachine = Machine(
+  {
+    context: {
+      hovering: null,
+      foreground: null,
+      background: null,
     },
-    {
-      guards: toolGuards,
-      actions: {
-        ...toolActions,
-        selectForeground: sendParent('SELECT_FOREGROUND'),
-        selectBackground: sendParent('SELECT_BACKGROUND'),
-        resetForeground: sendParent('RESET_FOREGROUND'),
-      },
-    }
-  );
+    on: {
+      FOREGROUND: { actions: 'setForeground' },
+      BACKGROUND: { actions: 'setBackground' },
+      HOVERING: { actions: 'setHovering' },
+      mouseup: [
+        {
+          cond: 'doubleClick',
+          actions: ['resetForeground', 'selectBackground'],
+        },
+        { cond: 'onForeground', actions: 'selectBackground' },
+        { actions: [(c, e) => console.log(c), 'selectForeground'] },
+      ],
+    },
+  },
+  {
+    guards: toolGuards,
+    actions: {
+      ...toolActions,
+      selectForeground: sendParent('SELECT_FOREGROUND'),
+      selectBackground: sendParent('SELECT_BACKGROUND'),
+      resetForeground: sendParent('RESET_FOREGROUND'),
+    },
+  }
+);
 
-export default createSelectMachine;
+export default selectMachine;

--- a/visualizer/src/service/tools/segment/selectMachine.js
+++ b/visualizer/src/service/tools/segment/selectMachine.js
@@ -18,7 +18,7 @@ const selectMachine = Machine(
           actions: ['resetForeground', 'selectBackground'],
         },
         { cond: 'onForeground', actions: 'selectBackground' },
-        { actions: [(c, e) => console.log(c), 'selectForeground'] },
+        { actions: 'selectForeground' },
       ],
     },
   },

--- a/visualizer/src/service/tools/segment/selectMachine.js
+++ b/visualizer/src/service/tools/segment/selectMachine.js
@@ -1,18 +1,18 @@
 import { Machine, sendParent } from 'xstate';
 import { toolActions, toolGuards } from './toolUtils';
 
-const createSelectMachine = ({ label, foreground, background }) =>
+const createSelectMachine = () =>
   Machine(
     {
       context: {
-        label,
-        foreground,
-        background,
+        hovering: null,
+        foreground: null,
+        background: null,
       },
       on: {
         FOREGROUND: { actions: 'setForeground' },
         BACKGROUND: { actions: 'setBackground' },
-        LABEL: { actions: 'setLabel' },
+        HOVERING: { actions: 'setHovering' },
         mouseup: [
           {
             cond: 'doubleClick',

--- a/visualizer/src/service/tools/segment/selectMachine.js
+++ b/visualizer/src/service/tools/segment/selectMachine.js
@@ -29,7 +29,7 @@ const createSelectMachine = ({ label, foreground, background }) =>
         ...toolActions,
         selectForeground: sendParent('SELECT_FOREGROUND'),
         selectBackground: sendParent('SELECT_BACKGROUND'),
-        resetForeground: sendParent({ type: 'FOREGROUND', foreground: 0 }),
+        resetForeground: sendParent('RESET_FOREGROUND'),
       },
     }
   );

--- a/visualizer/src/service/tools/segment/thresholdMachine.js
+++ b/visualizer/src/service/tools/segment/thresholdMachine.js
@@ -13,6 +13,7 @@ const thresholdMachine = Machine(
     states: {
       idle: {
         on: {
+          EXIT: 'idle',
           mousedown: { target: 'dragging', actions: 'saveFirstPoint' },
         },
       },
@@ -23,7 +24,6 @@ const thresholdMachine = Machine(
       },
     },
     on: {
-      EXIT: '.idle',
       COORDINATES: { actions: 'setCoordinates' },
       FOREGROUND: { actions: 'setForeground' },
     },

--- a/visualizer/src/service/tools/segment/thresholdMachine.js
+++ b/visualizer/src/service/tools/segment/thresholdMachine.js
@@ -24,6 +24,7 @@ const createThresholdMachine = ({ x, y, foreground }) =>
         },
       },
       on: {
+        EXIT: '.idle',
         COORDINATES: { actions: 'setCoordinates' },
         FOREGROUND: { actions: 'setForeground' },
       },

--- a/visualizer/src/service/tools/segment/thresholdMachine.js
+++ b/visualizer/src/service/tools/segment/thresholdMachine.js
@@ -8,7 +8,7 @@ const thresholdMachine = Machine(
       x: null,
       y: null,
       foreground: null,
-      firstPoint: null,
+      firstPoint: [null, null],
     },
     states: {
       idle: {

--- a/visualizer/src/service/tools/segment/thresholdMachine.js
+++ b/visualizer/src/service/tools/segment/thresholdMachine.js
@@ -1,15 +1,15 @@
 import { assign, Machine, sendParent } from 'xstate';
 import { toolActions, toolGuards } from './toolUtils';
 
-const createThresholdMachine = ({ x, y, foreground }) =>
+const createThresholdMachine = () =>
   Machine(
     {
       initial: 'idle',
       context: {
-        x,
-        y,
-        foreground,
-        firstPoint: [0, 0],
+        x: null,
+        y: null,
+        foreground: null,
+        firstPoint: null,
       },
       states: {
         idle: {

--- a/visualizer/src/service/tools/segment/thresholdMachine.js
+++ b/visualizer/src/service/tools/segment/thresholdMachine.js
@@ -1,53 +1,52 @@
 import { assign, Machine, sendParent } from 'xstate';
 import { toolActions, toolGuards } from './toolUtils';
 
-const createThresholdMachine = () =>
-  Machine(
-    {
-      initial: 'idle',
-      context: {
-        x: null,
-        y: null,
-        foreground: null,
-        firstPoint: null,
-      },
-      states: {
-        idle: {
-          on: {
-            mousedown: { target: 'dragging', actions: 'saveFirstPoint' },
-          },
-        },
-        dragging: {
-          on: {
-            mouseup: { target: 'idle', actions: 'threshold' },
-          },
+const thresholdMachine = Machine(
+  {
+    initial: 'idle',
+    context: {
+      x: null,
+      y: null,
+      foreground: null,
+      firstPoint: null,
+    },
+    states: {
+      idle: {
+        on: {
+          mousedown: { target: 'dragging', actions: 'saveFirstPoint' },
         },
       },
-      on: {
-        EXIT: '.idle',
-        COORDINATES: { actions: 'setCoordinates' },
-        FOREGROUND: { actions: 'setForeground' },
+      dragging: {
+        on: {
+          mouseup: { target: 'idle', actions: 'threshold' },
+        },
       },
     },
-    {
-      guards: toolGuards,
-      actions: {
-        ...toolActions,
-        saveFirstPoint: assign({ firstPoint: ({ x, y }) => [x, y] }),
-        threshold: sendParent(({ foreground, firstPoint, x, y }, event) => ({
-          type: 'EDIT',
-          action: 'threshold',
-          args: {
-            x1: firstPoint[0],
-            y1: firstPoint[1],
-            x2: x,
-            y2: y,
-            // frame: context.frame,
-            label: foreground,
-          },
-        })),
-      },
-    }
-  );
+    on: {
+      EXIT: '.idle',
+      COORDINATES: { actions: 'setCoordinates' },
+      FOREGROUND: { actions: 'setForeground' },
+    },
+  },
+  {
+    guards: toolGuards,
+    actions: {
+      ...toolActions,
+      saveFirstPoint: assign({ firstPoint: ({ x, y }) => [x, y] }),
+      threshold: sendParent(({ foreground, firstPoint, x, y }, event) => ({
+        type: 'EDIT',
+        action: 'threshold',
+        args: {
+          x1: firstPoint[0],
+          y1: firstPoint[1],
+          x2: x,
+          y2: y,
+          // frame: context.frame,
+          label: foreground,
+        },
+      })),
+    },
+  }
+);
 
-export default createThresholdMachine;
+export default thresholdMachine;

--- a/visualizer/src/service/tools/segment/toolUtils.js
+++ b/visualizer/src/service/tools/segment/toolUtils.js
@@ -3,16 +3,16 @@ import { assign } from 'xstate';
 // actions to save data from events in context
 export const toolActions = {
   setCoordinates: assign((_, { x, y }) => ({ x, y })),
-  setLabel: assign((_, { label }) => ({ label })),
-  setForeground: assign({ foreground: (_, { foreground }) => foreground }),
-  setBackground: assign({ background: (_, { background }) => background }),
-  setSelected: assign({ selected: (_, { selected }) => selected }),
+  setHovering: assign((_, { hovering }) => ({ hovering })),
+  setForeground: assign((_, { foreground }) => ({ foreground })),
+  setBackground: assign((_, { background }) => ({ background })),
+  setSelected: assign((_, { selected }) => ({ selected })),
 };
 
 export const toolGuards = {
   shift: (_, event) => event.shiftKey,
   doubleClick: (_, event) => event.detail === 2,
-  onBackground: ({ label, background }) => label === background,
-  onForeground: ({ label, foreground }) => label === foreground,
-  onNoLabel: ({ label }) => label === 0,
+  onBackground: ({ hovering, background }) => hovering === background,
+  onForeground: ({ hovering, foreground }) => hovering === foreground,
+  onNoLabel: ({ hovering }) => hovering === 0,
 };

--- a/visualizer/src/service/tools/segment/trimMachine.js
+++ b/visualizer/src/service/tools/segment/trimMachine.js
@@ -1,40 +1,39 @@
 import { Machine, sendParent } from 'xstate';
 import { toolActions, toolGuards } from './toolUtils';
 
-const createTrimMachine = () =>
-  Machine(
-    {
-      context: {
-        x: null,
-        y: null,
-        label: null,
-        foreground: null,
-        background: null,
-      },
-      on: {
-        COORDINATES: { actions: 'setCoordinates' },
-        HOVERING: { actions: 'setHovering' },
-        FOREGROUND: { actions: 'setForeground' },
-        BACKGROUND: { actions: 'setBackground' },
-        mouseup: [{ cond: 'onNoLabel' }, { actions: ['selectForeground', 'trim'] }],
-      },
+const trimMachine = Machine(
+  {
+    context: {
+      x: null,
+      y: null,
+      label: null,
+      foreground: null,
+      background: null,
     },
-    {
-      guards: toolGuards,
-      actions: {
-        ...toolActions,
-        selectForeground: sendParent('SELECT_FOREGROUND'),
-        trim: sendParent(({ hovering, x, y }, event) => ({
-          type: 'EDIT',
-          action: 'trim_pixels',
-          args: {
-            label: hovering,
-            x_location: x,
-            y_location: y,
-          },
-        })),
-      },
-    }
-  );
+    on: {
+      COORDINATES: { actions: 'setCoordinates' },
+      HOVERING: { actions: 'setHovering' },
+      FOREGROUND: { actions: 'setForeground' },
+      BACKGROUND: { actions: 'setBackground' },
+      mouseup: [{ cond: 'onNoLabel' }, { actions: ['selectForeground', 'trim'] }],
+    },
+  },
+  {
+    guards: toolGuards,
+    actions: {
+      ...toolActions,
+      selectForeground: sendParent('SELECT_FOREGROUND'),
+      trim: sendParent(({ hovering, x, y }, event) => ({
+        type: 'EDIT',
+        action: 'trim_pixels',
+        args: {
+          label: hovering,
+          x_location: x,
+          y_location: y,
+        },
+      })),
+    },
+  }
+);
 
-export default createTrimMachine;
+export default trimMachine;

--- a/visualizer/src/service/tools/segment/trimMachine.js
+++ b/visualizer/src/service/tools/segment/trimMachine.js
@@ -1,19 +1,19 @@
 import { Machine, sendParent } from 'xstate';
 import { toolActions, toolGuards } from './toolUtils';
 
-const createTrimMachine = ({ x, y, label, foreground, background }) =>
+const createTrimMachine = () =>
   Machine(
     {
       context: {
-        x,
-        y,
-        label,
-        foreground,
-        background,
+        x: null,
+        y: null,
+        label: null,
+        foreground: null,
+        background: null,
       },
       on: {
         COORDINATES: { actions: 'setCoordinates' },
-        LABEL: { actions: 'setLabel' },
+        HOVERING: { actions: 'setHovering' },
         FOREGROUND: { actions: 'setForeground' },
         BACKGROUND: { actions: 'setBackground' },
         mouseup: [{ cond: 'onNoLabel' }, { actions: ['selectForeground', 'trim'] }],
@@ -24,11 +24,11 @@ const createTrimMachine = ({ x, y, label, foreground, background }) =>
       actions: {
         ...toolActions,
         selectForeground: sendParent('SELECT_FOREGROUND'),
-        trim: sendParent(({ label, x, y }, event) => ({
+        trim: sendParent(({ hovering, x, y }, event) => ({
           type: 'EDIT',
           action: 'trim_pixels',
           args: {
-            label: label,
+            label: hovering,
             x_location: x,
             y_location: y,
           },

--- a/visualizer/src/service/tools/segment/watershedMachine.js
+++ b/visualizer/src/service/tools/segment/watershedMachine.js
@@ -1,79 +1,78 @@
 import { assign, Machine, sendParent } from 'xstate';
 import { toolActions, toolGuards } from './toolUtils';
 
-const createWatershedMachine = () =>
-  Machine(
-    {
-      context: {
-        x: null,
-        y: null,
-        hovering: null,
-        foreground: null,
-        background: null,
-        storedLabel: null,
-        storedX: null,
-        storedY: null,
-      },
-      on: {
-        COORDINATES: { actions: 'setCoordinates' },
-        HOVERING: { actions: 'setHovering' },
-        FOREGROUND: { actions: 'setForeground' },
-        BACKGROUND: { actions: 'setBackground' },
-      },
-      initial: 'idle',
-      states: {
-        idle: {
-          on: {
-            mouseup: [
-              { cond: 'onNoLabel' },
-              {
-                target: 'clicked',
-                actions: ['selectForeground', 'storeClick'],
-              },
-            ],
-          },
-        },
-        clicked: {
-          on: {
-            FOREGROUND: { actions: 'setForeground', target: 'idle' },
-            mouseup: {
-              cond: 'validSecondSeed',
-              target: 'idle',
-              actions: ['watershed', 'newBackground'],
+const watershedMachine = Machine(
+  {
+    context: {
+      x: null,
+      y: null,
+      hovering: null,
+      foreground: null,
+      background: null,
+      storedLabel: null,
+      storedX: null,
+      storedY: null,
+    },
+    on: {
+      COORDINATES: { actions: 'setCoordinates' },
+      HOVERING: { actions: 'setHovering' },
+      FOREGROUND: { actions: 'setForeground' },
+      BACKGROUND: { actions: 'setBackground' },
+    },
+    initial: 'idle',
+    states: {
+      idle: {
+        on: {
+          mouseup: [
+            { cond: 'onNoLabel' },
+            {
+              target: 'clicked',
+              actions: ['selectForeground', 'storeClick'],
             },
+          ],
+        },
+      },
+      clicked: {
+        on: {
+          FOREGROUND: { actions: 'setForeground', target: 'idle' },
+          mouseup: {
+            cond: 'validSecondSeed',
+            target: 'idle',
+            actions: ['watershed', 'newBackground'],
           },
         },
       },
     },
-    {
-      guards: {
-        ...toolGuards,
-        validSecondSeed: ({ hovering, foreground, x, y, storedX, storedY }) =>
-          hovering === foreground && // same label
-          (x !== storedX || y !== storedY), // different point
-      },
-      actions: {
-        ...toolActions,
-        storeClick: assign({
-          storedLabel: ({ hovering }) => hovering,
-          storedX: ({ x }) => x,
-          storedY: ({ y }) => y,
-        }),
-        selectForeground: sendParent('SELECT_FOREGROUND'),
-        newBackground: sendParent({ type: 'BACKGROUND', background: 0 }),
-        watershed: sendParent(({ storedLabel, storedX, storedY, x, y }) => ({
-          type: 'EDIT',
-          action: 'watershed',
-          args: {
-            label: storedLabel,
-            x1_location: storedX,
-            y1_location: storedY,
-            x2_location: x,
-            y2_location: y,
-          },
-        })),
-      },
-    }
-  );
+  },
+  {
+    guards: {
+      ...toolGuards,
+      validSecondSeed: ({ hovering, foreground, x, y, storedX, storedY }) =>
+        hovering === foreground && // same label
+        (x !== storedX || y !== storedY), // different point
+    },
+    actions: {
+      ...toolActions,
+      storeClick: assign({
+        storedLabel: ({ hovering }) => hovering,
+        storedX: ({ x }) => x,
+        storedY: ({ y }) => y,
+      }),
+      selectForeground: sendParent('SELECT_FOREGROUND'),
+      newBackground: sendParent({ type: 'BACKGROUND', background: 0 }),
+      watershed: sendParent(({ storedLabel, storedX, storedY, x, y }) => ({
+        type: 'EDIT',
+        action: 'watershed',
+        args: {
+          label: storedLabel,
+          x1_location: storedX,
+          y1_location: storedY,
+          x2_location: x,
+          y2_location: y,
+        },
+      })),
+    },
+  }
+);
 
-export default createWatershedMachine;
+export default watershedMachine;

--- a/visualizer/src/service/tools/segment/watershedMachine.js
+++ b/visualizer/src/service/tools/segment/watershedMachine.js
@@ -34,6 +34,7 @@ const watershedMachine = Machine(
       },
       clicked: {
         on: {
+          EXIT: 'idle',
           FOREGROUND: { actions: 'setForeground', target: 'idle' },
           mouseup: {
             cond: 'validSecondSeed',

--- a/visualizer/src/service/tools/segment/watershedMachine.js
+++ b/visualizer/src/service/tools/segment/watershedMachine.js
@@ -1,22 +1,22 @@
 import { assign, Machine, sendParent } from 'xstate';
 import { toolActions, toolGuards } from './toolUtils';
 
-const createWatershedMachine = ({ x, y, label, foreground, background }) =>
+const createWatershedMachine = () =>
   Machine(
     {
       context: {
-        x,
-        y,
-        label,
-        foreground,
-        background,
-        storedLabel: 0,
-        storedX: 0,
-        storedY: 0,
+        x: null,
+        y: null,
+        hovering: null,
+        foreground: null,
+        background: null,
+        storedLabel: null,
+        storedX: null,
+        storedY: null,
       },
       on: {
         COORDINATES: { actions: 'setCoordinates' },
-        LABEL: { actions: 'setLabel' },
+        HOVERING: { actions: 'setHovering' },
         FOREGROUND: { actions: 'setForeground' },
         BACKGROUND: { actions: 'setBackground' },
       },
@@ -48,14 +48,14 @@ const createWatershedMachine = ({ x, y, label, foreground, background }) =>
     {
       guards: {
         ...toolGuards,
-        validSecondSeed: ({ label, foreground, x, y, storedX, storedY }) =>
-          label === foreground && // same label
+        validSecondSeed: ({ hovering, foreground, x, y, storedX, storedY }) =>
+          hovering === foreground && // same label
           (x !== storedX || y !== storedY), // different point
       },
       actions: {
         ...toolActions,
         storeClick: assign({
-          storedLabel: ({ label }) => label,
+          storedLabel: ({ hovering }) => hovering,
           storedX: ({ x }) => x,
           storedY: ({ y }) => y,
         }),

--- a/visualizer/src/service/tools/segmentMachine.js
+++ b/visualizer/src/service/tools/segmentMachine.js
@@ -15,13 +15,13 @@ const panState = {
     pan: {
       entry: sendParent({ type: 'SET_PAN_ON_DRAG', panOnDrag: true }),
       on: {
-        SET_TOOL: { cond: 'noPanTool', target: 'noPan' },
+        SET_TOOL: { cond: 'isNoPanTool', target: 'noPan' },
       },
     },
     noPan: {
       entry: sendParent({ type: 'SET_PAN_ON_DRAG', panOnDrag: false }),
       on: {
-        SET_TOOL: { cond: 'panTool', target: 'pan' },
+        SET_TOOL: { cond: 'isPanTool', target: 'pan' },
       },
     },
   },
@@ -146,9 +146,15 @@ const segmentMachine = Machine(
         ['brush', 'select', 'trim', 'flood', 'threshold', 'watershed'].includes(tool),
       isGrayscaleTool: (_, { tool }) =>
         ['brush', 'select', 'trim', 'flood', 'threshold', 'watershed'].includes(tool),
+      isNoPanTool: (_, { tool }) => ['brush', 'threshold'].includes(tool),
+      isPanTool: (_, { tool }) => ['select', 'trim', 'flood', 'watershed'].includes(tool),
     },
     actions: {
       ...editActions,
+      setTool: pure((context, event) => [
+        send('EXIT', { to: context.tool }),
+        assign({ tool: event.tool }),
+      ]),
       save: respond(({ tool }) => ({ type: 'RESTORE', tool })),
       restore: assign((_, { tool }) => ({ tool })),
       spawnTools: assign({
@@ -162,7 +168,7 @@ const segmentMachine = Machine(
         }),
       }),
       forwardToTool: forwardTo(({ tool }) => tool),
-      forwardToTools: pure(({ tools }) => tools.map(tool => forwardTo(tool))),
+      forwardToTools: pure(({ tools }) => Object.values(tools).map(tool => forwardTo(tool))),
     },
   }
 );

--- a/visualizer/src/service/tools/segmentMachine.js
+++ b/visualizer/src/service/tools/segmentMachine.js
@@ -1,11 +1,11 @@
 import { actions, assign, forwardTo, Machine, send, sendParent, spawn } from 'xstate';
-import createBrushMachine from './segment/brushMachine';
-import createFloodMachine from './segment/floodMachine';
-import createSelectMachine from './segment/selectMachine';
-import createThresholdMachine from './segment/thresholdMachine';
+import brushMachine from './segment/brushMachine';
+import floodMachine from './segment/floodMachine';
+import selectMachine from './segment/selectMachine';
+import thresholdMachine from './segment/thresholdMachine';
 import { toolGuards } from './segment/toolUtils';
-import createTrimMachine from './segment/trimMachine';
-import createWatershedMachine from './segment/watershedMachine';
+import trimMachine from './segment/trimMachine';
+import watershedMachine from './segment/watershedMachine';
 
 const { pure, respond } = actions;
 
@@ -64,7 +64,7 @@ const syncState = {
     mouseup: { actions: 'forwardToTool' },
     // send to all tools
     COORDINATES: { actions: 'forwardToTools' },
-    LABEL: { actions: 'forwardToTools' },
+    HOVERING: { actions: 'forwardToTools' },
     FOREGROUND: { actions: 'forwardToTools' },
     BACKGROUND: { actions: 'forwardToTools' },
     SELECTED: { actions: 'forwardToTools' },
@@ -159,12 +159,12 @@ const segmentMachine = Machine(
       restore: assign((_, { tool }) => ({ tool })),
       spawnTools: assign({
         tools: context => ({
-          brush: spawn(createBrushMachine(context), 'brush'),
-          select: spawn(createSelectMachine(context), 'select'),
-          threshold: spawn(createThresholdMachine(context), 'threshold'),
-          trim: spawn(createTrimMachine(context), 'trim'),
-          flood: spawn(createFloodMachine(context), 'flood'),
-          watershed: spawn(createWatershedMachine(context), 'watershed'),
+          brush: spawn(brushMachine, 'brush'),
+          select: spawn(selectMachine, 'select'),
+          threshold: spawn(thresholdMachine, 'threshold'),
+          trim: spawn(trimMachine, 'trim'),
+          flood: spawn(floodMachine, 'flood'),
+          watershed: spawn(watershedMachine, 'watershed'),
         }),
       }),
       forwardToTool: forwardTo(({ tool }) => tool),

--- a/visualizer/src/service/tools/segmentMachine.js
+++ b/visualizer/src/service/tools/segmentMachine.js
@@ -3,7 +3,7 @@ import brushMachine from './segment/brushMachine';
 import floodMachine from './segment/floodMachine';
 import selectMachine from './segment/selectMachine';
 import thresholdMachine from './segment/thresholdMachine';
-import { toolGuards } from './segment/toolUtils';
+import { toolActions, toolGuards } from './segment/toolUtils';
 import trimMachine from './segment/trimMachine';
 import watershedMachine from './segment/watershedMachine';
 
@@ -65,9 +65,9 @@ const syncState = {
     // send to all tools
     COORDINATES: { actions: 'forwardToTools' },
     HOVERING: { actions: 'forwardToTools' },
-    FOREGROUND: { actions: 'forwardToTools' },
-    BACKGROUND: { actions: 'forwardToTools' },
-    SELECTED: { actions: 'forwardToTools' },
+    FOREGROUND: { actions: ['forwardToTools', 'setForeground'] },
+    BACKGROUND: { actions: ['forwardToTools', 'setBackground'] },
+    SELECTED: { actions: ['forwardToTools', 'setSelected'] },
   },
 };
 
@@ -114,6 +114,9 @@ const segmentMachine = Machine(
   {
     id: 'segment',
     context: {
+      foreground: null,
+      background: null,
+      selected: null,
       tool: 'select',
       tools: null,
     },
@@ -150,6 +153,7 @@ const segmentMachine = Machine(
       isPanTool: (_, { tool }) => ['select', 'trim', 'flood', 'watershed'].includes(tool),
     },
     actions: {
+      ...toolActions,
       ...editActions,
       setTool: pure((context, event) => [
         send('EXIT', { to: context.tool }),

--- a/visualizer/src/service/tools/segmentMachine.js
+++ b/visualizer/src/service/tools/segmentMachine.js
@@ -3,35 +3,37 @@ import createBrushMachine from './segment/brushMachine';
 import createFloodMachine from './segment/floodMachine';
 import createSelectMachine from './segment/selectMachine';
 import createThresholdMachine from './segment/thresholdMachine';
-import { toolActions, toolGuards } from './segment/toolUtils';
+import { toolGuards } from './segment/toolUtils';
 import createTrimMachine from './segment/trimMachine';
 import createWatershedMachine from './segment/watershedMachine';
 
 const { pure, respond } = actions;
 
-// TODO: move to config file?
-const colorTools = ['brush', 'select', 'trim', 'flood'];
-
-const createToolMachineLookup = {
-  brush: createBrushMachine,
-  select: createSelectMachine,
-  threshold: createThresholdMachine,
-  trim: createTrimMachine,
-  flood: createFloodMachine,
-  watershed: createWatershedMachine,
+const panState = {
+  initial: 'pan',
+  states: {
+    pan: {
+      entry: sendParent({ type: 'SET_PAN_ON_DRAG', panOnDrag: true }),
+      on: {
+        SET_TOOL: { cond: 'noPanTool', target: 'noPan' },
+      },
+    },
+    noPan: {
+      entry: sendParent({ type: 'SET_PAN_ON_DRAG', panOnDrag: false }),
+      on: {
+        SET_TOOL: { cond: 'panTool', target: 'pan' },
+      },
+    },
+  },
 };
 
-const createToolMachine = context => {
-  const { tool } = context;
-  return spawn(createToolMachineLookup[tool](context), 'tool');
-};
-
-const colorModeState = {
+const displayState = {
   initial: 'color',
   states: {
     color: {
       on: {
         GRAYSCALE: 'grayscale',
+        SET_TOOL: { cond: 'isColorTool', actions: 'setTool' },
       },
     },
     grayscale: {
@@ -40,71 +42,33 @@ const colorModeState = {
           { target: 'color', cond: 'usingColorTool' },
           { target: 'color', actions: 'useSelect' },
         ],
-        USE_WATERSHED: { actions: 'useWatershed' },
-        USE_THRESHOLD: { actions: 'useThreshold' },
+        SET_TOOL: { cond: 'isGrayscaleTool', actions: 'setTool' },
         AUTOFIT: { actions: 'autofit' },
       },
     },
   },
   on: {
-    USE_BRUSH: { actions: 'useBrush' },
-    USE_ERASER: { actions: 'useEraser' },
-    USE_SELECT: { actions: 'useSelect' },
-    USE_TRIM: { actions: 'useTrim' },
-    USE_FLOOD: { actions: 'useFlood' },
+    // available in all display states
+    SWAP: { actions: 'swap' },
+    REPLACE: { actions: 'replace' },
+    DELETE: { actions: 'delete' },
+    ERODE: { actions: 'erode' },
+    DILATE: { actions: 'dilate' },
   },
 };
 
-const useToolActions = {
-  useBrush: pure(({ foreground: fg, background: bg }) => [
-    assign({
-      tool: 'brush',
-      toolActor: context => spawn(createBrushMachine(context), 'tool'),
-    }),
-    sendParent({ type: 'SET_PAN_ON_DRAG', panOnDrag: false }),
-  ]),
-  useEraser: pure(({ foreground: fg, background: bg }) => [
-    assign({
-      tool: 'brush',
-      toolActor: context => spawn(createBrushMachine(context), 'tool'),
-    }),
-    sendParent({ type: 'SET_PAN_ON_DRAG', panOnDrag: false }),
-  ]),
-  useSelect: pure(() => [
-    assign({
-      tool: 'select',
-      toolActor: context => spawn(createSelectMachine(context), 'tool'),
-    }),
-    sendParent({ type: 'SET_PAN_ON_DRAG', panOnDrag: true }),
-  ]),
-  useTrim: pure(() => [
-    assign({
-      tool: 'trim',
-      toolActor: context => spawn(createTrimMachine(context), 'tool'),
-    }),
-    sendParent({ type: 'SET_PAN_ON_DRAG', panOnDrag: true }),
-  ]),
-  useFlood: pure(() => [
-    assign({
-      tool: 'flood',
-      toolActor: context => spawn(createFloodMachine(context), 'tool'),
-    }),
-    sendParent({ type: 'SET_PAN_ON_DRAG', panOnDrag: true }),
-  ]),
-  useWatershed: pure(() => [
-    assign({
-      tool: 'watershed',
-      toolActor: context => spawn(createWatershedMachine(context), 'tool'),
-    }),
-    sendParent({ type: 'SET_PAN_ON_DRAG', panOnDrag: true }),
-  ]),
-  useThreshold: pure(() => [
-    assign({
-      tool: 'threshold',
-      toolActor: context => spawn(createThresholdMachine(context), 'tool'),
-    }),
-    sendParent({ type: 'SET_PAN_ON_DRAG', panOnDrag: false }),
-  ]),
+const syncState = {
+  on: {
+    // only send to tool in use
+    mousedown: { actions: 'forwardToTool' },
+    mouseup: { actions: 'forwardToTool' },
+    // send to all tools
+    COORDINATES: { actions: 'forwardToTools' },
+    LABEL: { actions: 'forwardToTools' },
+    FOREGROUND: { actions: 'forwardToTools' },
+    BACKGROUND: { actions: 'forwardToTools' },
+    SELECTED: { actions: 'forwardToTools' },
+  },
 };
 
 const editActions = {
@@ -150,44 +114,22 @@ const segmentMachine = Machine(
   {
     id: 'segment',
     context: {
-      label: 0,
-      selected: 1,
-      foreground: 1,
-      background: 0,
-      x: 0,
-      y: 0,
       tool: 'select',
-      toolActor: null,
+      tools: null,
     },
-    entry: 'spawnTool',
+    entry: 'spawnTools',
     type: 'parallel',
     states: {
-      colorMode: colorModeState,
+      display: displayState,
+      pan: panState,
+      sync: syncState,
     },
     on: {
       EDIT: { actions: sendParent((_, e) => e) },
 
-      mousedown: { actions: 'forwardToTool' },
-      mouseup: { actions: 'forwardToTool' },
-
-      SWAP: { actions: 'swap' },
-      REPLACE: { actions: 'replace' },
-      DELETE: { actions: 'delete' },
-      ERODE: { actions: 'erode' },
-      DILATE: { actions: 'dilate' },
-
-      // sync context with tools
-      COORDINATES: {
-        actions: ['setCoordinates', 'forwardToTool'],
-      },
-      LABEL: { actions: ['setLabel', 'forwardToTool'] },
-      FOREGROUND: { actions: ['setForeground', 'forwardToTool'] },
-      BACKGROUND: { actions: ['setBackground', 'forwardToTool'] },
-      SELECTED: { actions: ['setSelected', 'forwardToTool'] },
-
       // undo/redo actions
       SAVE: { actions: 'save' },
-      RESTORE: { actions: ['restore', 'spawnTool', respond('RESTORED')] },
+      RESTORE: { actions: ['restore', respond('RESTORED')] },
 
       // select events (from select tool)
       SELECT_FOREGROUND: { actions: sendParent((c, e) => e) },
@@ -198,16 +140,29 @@ const segmentMachine = Machine(
   {
     guards: {
       ...toolGuards,
-      usingColorTool: ({ tool }) => colorTools.includes(tool),
+      usingColorTool: ({ tool }) => ['brush', 'select', 'trim', 'flood'].includes(tool),
+      isColorTool: (_, { tool }) => ['brush', 'select', 'trim', 'flood'].includes(tool),
+      usingGrayscaleTool: ({ tool }) =>
+        ['brush', 'select', 'trim', 'flood', 'threshold', 'watershed'].includes(tool),
+      isGrayscaleTool: (_, { tool }) =>
+        ['brush', 'select', 'trim', 'flood', 'threshold', 'watershed'].includes(tool),
     },
     actions: {
-      ...toolActions,
       ...editActions,
-      ...useToolActions,
       save: respond(({ tool }) => ({ type: 'RESTORE', tool })),
       restore: assign((_, { tool }) => ({ tool })),
-      spawnTool: assign({ toolActor: createToolMachine }),
-      forwardToTool: forwardTo(({ toolActor }) => toolActor),
+      spawnTools: assign({
+        tools: context => ({
+          brush: spawn(createBrushMachine(context), 'brush'),
+          select: spawn(createSelectMachine(context), 'select'),
+          threshold: spawn(createThresholdMachine(context), 'threshold'),
+          trim: spawn(createTrimMachine(context), 'trim'),
+          flood: spawn(createFloodMachine(context), 'flood'),
+          watershed: spawn(createWatershedMachine(context), 'watershed'),
+        }),
+      }),
+      forwardToTool: forwardTo(({ tool }) => tool),
+      forwardToTools: pure(({ tools }) => tools.map(tool => forwardTo(tool))),
     },
   }
 );

--- a/visualizer/src/service/tools/segmentMachine.js
+++ b/visualizer/src/service/tools/segmentMachine.js
@@ -9,6 +9,11 @@ import watershedMachine from './segment/watershedMachine';
 
 const { pure, respond } = actions;
 
+const colorTools = ['brush', 'select', 'trim', 'flood'];
+const grayscaleTools = ['brush', 'select', 'trim', 'flood', 'threshold', 'watershed'];
+const panTools = ['select', 'trim', 'flood', 'watershed'];
+const noPanTools = ['brush', 'threshold'];
+
 const panState = {
   initial: 'pan',
   states: {
@@ -143,14 +148,12 @@ const segmentMachine = Machine(
   {
     guards: {
       ...toolGuards,
-      usingColorTool: ({ tool }) => ['brush', 'select', 'trim', 'flood'].includes(tool),
-      isColorTool: (_, { tool }) => ['brush', 'select', 'trim', 'flood'].includes(tool),
-      usingGrayscaleTool: ({ tool }) =>
-        ['brush', 'select', 'trim', 'flood', 'threshold', 'watershed'].includes(tool),
-      isGrayscaleTool: (_, { tool }) =>
-        ['brush', 'select', 'trim', 'flood', 'threshold', 'watershed'].includes(tool),
-      isNoPanTool: (_, { tool }) => ['brush', 'threshold'].includes(tool),
-      isPanTool: (_, { tool }) => ['select', 'trim', 'flood', 'watershed'].includes(tool),
+      usingColorTool: ({ tool }) => colorTools.includes(tool),
+      isColorTool: (_, { tool }) => colorTools.includes(tool),
+      usingGrayscaleTool: ({ tool }) => grayscaleTools.includes(tool),
+      isGrayscaleTool: (_, { tool }) => grayscaleTools.includes(tool),
+      isNoPanTool: (_, { tool }) => noPanTools.includes(tool),
+      isPanTool: (_, { tool }) => panTools.includes(tool),
     },
     actions: {
       ...toolActions,


### PR DESCRIPTION
When using tool hotkeys to switch out the brush and threshold currently causes UI crashes as the tool changes before the `BrushCanvas` or `ThresholdCanvas` is removed, causing these canvases to access a brush machine or threshold machine that no longer exists. 

Previously, we spawned one tool machine at a time and deleted the previous tool machine when switch between tools. With this PR, we spawn all of the tools and keep them in the `segmentMachine` and switch between these pre-existing tool. Instead of a `useTool` hook that provides the current tool, we have specific `useBrush` and `useThreshold` hooks that provide the persistent brush or threshold actors so these components don't crash even if the component is out of sync with the current tool.

This PR also includes a couple of fixes and improvements that I noticed while making these changes.

 - refactoring switching between tools in `segmentMachine`
 - fixing the flood tool to flood immediately instead of first selecting the background and then flooding
 - fixing double clicks with the select tool to deselect the foreground because is was sending the wrong event
 - changing machines to start with `null` in their context and sending events to initialize them to 