### PR TITLE
Drop node v10 and add v16 and v17 support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,55 +6,54 @@ name: tests
 on: [push, pull_request]
 
 jobs:
-
   frontend-tests:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x, 16.x, 17.x]
 
     steps:
-    - uses: actions/checkout@v1
+      - uses: actions/checkout@v1
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node-version }}
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
 
-    - name: Cache node_modules
-      uses: actions/cache@v2
-      with:
-        path: 'visualizer/**/node_modules'
-        key: ${{ runner.os }}-modules-${{ hashFiles('visualizer/**/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-
-          ${{ runner.os }}-
+      - name: Cache node_modules
+        uses: actions/cache@v2
+        with:
+          path: 'visualizer/**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('visualizer/**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+            ${{ runner.os }}-
 
-    - name: Yarn Install
-      working-directory: visualizer
-      run: yarn
+      - name: Yarn Install
+        working-directory: visualizer
+        run: yarn
 
-    - name: Lint
-      working-directory: visualizer
-      run: yarn lint
+      - name: Lint
+        working-directory: visualizer
+        run: yarn lint
 
-    - name: Unit Tests
-      working-directory: visualizer
-      run: yarn test --coverage
-      env:
-        CI: true
+      - name: Unit Tests
+        working-directory: visualizer
+        run: yarn test --coverage
+        env:
+          CI: true
 
-    - name: Coveralls Parallel
-      uses: coverallsapp/github-action@master
-      env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-      with:
-        base-path: visualizer
-        path-to-lcov: visualizer/coverage/lcov.info
-        github-token: ${{ secrets.github_token }}
-        flag-name: node-${{ matrix.node-version }}
-        parallel: true
+      - name: Coveralls Parallel
+        uses: coverallsapp/github-action@master
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+        with:
+          base-path: visualizer
+          path-to-lcov: visualizer/coverage/lcov.info
+          github-token: ${{ secrets.github_token }}
+          flag-name: node-${{ matrix.node-version }}
+          parallel: true
 
   backend-tests:
     runs-on: ubuntu-latest
@@ -64,42 +63,42 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Cache pip
-      uses: actions/cache@v2
-      with:
-        # This path is specific to Ubuntu
-        path: ~/.cache/pip
-        # Look to see if there is a cache hit for the corresponding requirements file
-        key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-
-          ${{ runner.os }}-
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          # This path is specific to Ubuntu
+          path: ~/.cache/pip
+          # Look to see if there is a cache hit for the corresponding requirements file
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
 
-    - name: Install Dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r requirements-test.txt
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-test.txt
 
-    - name: Run PyTest
-      run: |
-        pytest deepcell_label --cov deepcell_label --pep8
+      - name: Run PyTest
+        run: |
+          pytest deepcell_label --cov deepcell_label --pep8
 
-    - name: Coveralls
-      if: env.COVERALLS_REPO_TOKEN != null
-      env:
-        COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        COVERALLS_FLAG_NAME: python-${{ matrix.python-version }}
-        COVERALLS_PARALLEL: true
-      run: |
-        coveralls
+      - name: Coveralls
+        if: env.COVERALLS_REPO_TOKEN != null
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          COVERALLS_FLAG_NAME: python-${{ matrix.python-version }}
+          COVERALLS_PARALLEL: true
+        run: |
+          coveralls
 
   coveralls:
     name: Finish Coveralls


### PR DESCRIPTION
Our GitHub Actions workflow have been failing as some of our node dependencies have dropped support for node v10 and now expect version >= 12 as node v10 reached end of life earlier this year. We drop node v10 from our testing workflows and add the current versions of node v16 and v17.
