### PR TITLE
Upgrade to react-router v6

### DIFF
--- a/visualizer/package.json
+++ b/visualizer/package.json
@@ -36,7 +36,7 @@
     "react-dom": "^17.0.1",
     "react-dropzone": "^11.4.0",
     "react-icons": "^4.2.0",
-    "react-router-dom": "6",
+    "react-router-dom": "^6.0.0",
     "react-scripts": "4.0.2",
     "typescript": "^4.2.4",
     "web-vitals": "^1.0.1",

--- a/visualizer/package.json
+++ b/visualizer/package.json
@@ -36,7 +36,7 @@
     "react-dom": "^17.0.1",
     "react-dropzone": "^11.4.0",
     "react-icons": "^4.2.0",
-    "react-router-dom": "^5.2.0",
+    "react-router-dom": "6",
     "react-scripts": "4.0.2",
     "typescript": "^4.2.4",
     "web-vitals": "^1.0.1",

--- a/visualizer/src/App.js
+++ b/visualizer/src/App.js
@@ -1,4 +1,4 @@
-import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import Label from './Label';
 import Load from './Load/Load';
 import ProjectContext from './ProjectContext';
@@ -13,16 +13,17 @@ import service from './service/service';
 function App() {
   return (
     <Router>
-      <Switch>
-        <Route path='/project'>
-          <ProjectContext project={service}>
-            <Label />
-          </ProjectContext>
-        </Route>
-        <Route path='/'>
-          <Load />
-        </Route>
-      </Switch>
+      <Routes>
+        <Route path='/' element={<Load />} />
+        <Route
+          path='/project'
+          element={
+            <ProjectContext project={service}>
+              <Label />
+            </ProjectContext>
+          }
+        />
+      </Routes>
     </Router>
   );
 }


### PR DESCRIPTION
React Router released a [new major version 6](https://remix.run/blog/react-router-v6) which has more flexible hooks and is more composable. It replaces the <Switch> component with <Routes> which avoids bugs due to route ordering and lets us place the `/` route before the `/project` route, which @willgraf requested in a recent review.