### PR TITLE
Put a version ceiling on coveralls, 3.3.0 has a bug preventing builds.

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,5 +7,5 @@ pytest-flask-sqlalchemy
 pytest-lazy-fixture
 fakeredis
 six>=1.12
-coveralls
+coveralls>3,<3.3.0
 responses


### PR DESCRIPTION
## What
* Pin the `coveralls` version to be < 3.3.0.

## Why
* `coveralls` released [version 3.3.0](https://pypi.org/project/coveralls/) yesterday which is causing [builds to break](https://github.com/vanvalenlab/deepcell-label/runs/4111480977?check_suite_focus=true). This change prevents the new version from being installed.
