### PR TITLE
Add testing for python 3.9 and 3.10

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Run PyTest
         run: |
-          pytest deepcell_label --cov deepcell_label --pep8
+          pytest deepcell_label --cov deepcell_label --flake8
 
       - name: Coveralls
         if: env.COVERALLS_REPO_TOKEN != null

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,7 +60,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,7 +60,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,7 +60,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9, '3.10']
 
     steps:
       - uses: actions/checkout@v2

--- a/convert.py
+++ b/convert.py
@@ -80,7 +80,8 @@ def main():
             dest = file.parent / file.stem
         data_utils.trks_to_trk_folder(str(file), str(dest))
     else:
-        raise NotImplemented
+        raise NotImplementedError
+
 
 if __name__ == "__main__":
     main()

--- a/deepcell_label/__init__.py
+++ b/deepcell_label/__init__.py
@@ -3,10 +3,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import logging
-
 from flask import Flask
-from flask.logging import default_handler
 from flask_cors import CORS
 from flask_compress import Compress
 from flask_dropzone import Dropzone

--- a/deepcell_label/blueprints_test.py
+++ b/deepcell_label/blueprints_test.py
@@ -86,7 +86,7 @@ def test_redo(client):
 
 def test_create_project(client, mocker):
     mocker.patch('deepcell_label.blueprints.loaders.URLLoader', lambda *args: DummyLoader())
-    response = client.post(f'/api/project')
+    response = client.post('/api/project')
     assert response.status_code == 200
 
 
@@ -95,7 +95,7 @@ def test_create_project_dropped_npz(client):
     np.savez(npz, X=np.zeros((1, 1, 1, 1)), y=np.ones((1, 1, 1, 1)))
     npz.seek(0)
     data = {'file': (npz, 'test.npz')}
-    response = client.post(f'/api/project/dropped', data=data, content_type='multipart/form-data')
+    response = client.post('/api/project/dropped', data=data, content_type='multipart/form-data')
     assert response.status_code == 200
 
 
@@ -105,7 +105,7 @@ def test_create_project_dropped_tiff(client):
         writer.save(np.zeros((1, 1, 1, 1)))
         tifffile.seek(0)
     data = {'file': (tifffile, 'test.tiff')}
-    response = client.post(f'/api/project/dropped', data=data, content_type='multipart/form-data')
+    response = client.post('/api/project/dropped', data=data, content_type='multipart/form-data')
     assert response.status_code == 200
 
 
@@ -115,7 +115,7 @@ def test_create_project_dropped_png(client):
     img.save(png, format="png")
     png.seek(0)
     data = {'file': (png, 'test.png')}
-    response = client.post(f'/api/project/dropped', data=data, content_type='multipart/form-data')
+    response = client.post('/api/project/dropped', data=data, content_type='multipart/form-data')
     assert response.status_code == 200
 
 

--- a/deepcell_label/exporters_test.py
+++ b/deepcell_label/exporters_test.py
@@ -1,6 +1,5 @@
 """Tests for exporters.py"""
 
-import pytest
 import io
 
 from deepcell_label import models

--- a/deepcell_label/imgutils_test.py
+++ b/deepcell_label/imgutils_test.py
@@ -4,7 +4,6 @@ import os
 
 from skimage.io import imread
 import numpy as np
-import pytest
 
 from deepcell_label import imgutils
 from deepcell_label import models

--- a/deepcell_label/label_test.py
+++ b/deepcell_label/label_test.py
@@ -66,7 +66,6 @@ class TestBaseEdit():
         cell = 1
         feature = 0
         expected_new_label = 2
-        frame = 0
 
         with app.app_context():
             edit.action_new_single_cell(cell)
@@ -474,5 +473,5 @@ class TestTrackEdit():
             assert cell not in edit.frame[..., feature]
             assert expected_new_cell in edit.frame[..., feature]
             assert expected_new_cell in edit.labels.cell_ids[feature]
-            assert prev_track['frames'] == (tracks[cell]['frames'] +
-                                            tracks[expected_new_cell]['frames'])
+            assert prev_track['frames'] == (tracks[cell]['frames']
+                                            + tracks[expected_new_cell]['frames'])

--- a/deepcell_label/labelmaker_test.py
+++ b/deepcell_label/labelmaker_test.py
@@ -1,7 +1,6 @@
 """Tests for labelmaker.py"""
 
 import numpy as np
-import pytest
 
 from deepcell_label.labelmaker import LabelInfoMaker
 

--- a/deepcell_label/loaders_test.py
+++ b/deepcell_label/loaders_test.py
@@ -5,14 +5,12 @@ Tests for loading files in loaders.
 import io
 import zipfile
 
-import pytest
-
 import numpy as np
 import responses
 from PIL import Image
 from tifffile import TiffWriter
 
-from deepcell_label.loaders import URLLoader, FileLoader
+from deepcell_label.loaders import URLLoader
 
 
 @responses.activate

--- a/pytest.ini
+++ b/pytest.ini
@@ -25,7 +25,7 @@ norecursedirs=
 # E731 do not assign a lambda expression, use a def
 # W503 line break occurred before a binary operator
 
-pep8ignore=* E731
+flake8-ignore=* E731
 
-# Enable line length testing with maximum line length of 80
-pep8maxlinelength = 100
+# Enable line length testing with maximum line length of 100
+flake8-max-line-length = 100

--- a/pytest.ini
+++ b/pytest.ini
@@ -25,7 +25,7 @@ norecursedirs=
 # E731 do not assign a lambda expression, use a def
 # W503 line break occurred before a binary operator
 
-flake8-ignore=* E731
+flake8-ignore=* E731 W503
 
 # Enable line length testing with maximum line length of 100
 flake8-max-line-length = 100

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-pytest>=5.2,<6
+pytest~=6.2.5 
 pytest-cov==2.5.1
 pytest-mock
 pytest-pep8

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
 pytest~=6.2.5 
 pytest-cov==2.5.1
 pytest-mock
-pytest-pep8
+pytest-flake8
 pytest-flask
 pytest-flask-sqlalchemy
 pytest-lazy-fixture

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -6,6 +6,7 @@ pytest-flask
 pytest-flask-sqlalchemy
 pytest-lazy-fixture
 fakeredis
+flake8<4 # Pin flake8 to version 3 to prevent StringIO error (see tholo/pytest-flake8#81)
 six>=1.12
 coveralls>3,<3.3.0
 responses


### PR DESCRIPTION
In #287, we drop support for Python 3.6, but did not test for the newer Python releases 3.9 and 3.10. Here we add them to our test matrix to make sure our codebase works for these versions for when we'll need to switch to them down the road.

However, pytest-pep8 is incompatible with Python 3.10. Python 3.10 requires at least pytest 6.2.4 per [this issue](https://github.com/pytest-dev/pytest/issues/8539) and pytest-pep8 is incompatible with pytest 6, as seen in this error message
```
Direct construction of Pep8Item has been deprecated, please use Pep8Item.from_parent.
See https://docs.pytest.org/en/stable/deprecations.html#node-construction-changed-to-node-from-parent for more details.
```

As [pytest-pep8](https://pypi.org/project/pytest-pep8/) is not an actively mantained project and the last release was in 2014, I switched to [flake8](https://pypi.org/project/flake8/) and [pytest-flake8](https://pypi.org/project/pytest-flake8/). Flake8 checks for pep8 as well as pyflakes and circular complexity, keeping the style checks and adding some error checks.

In summary, this PR contains:

- additions to tests.yaml to test Python 3.9 and 3.10
- switches out pep8 checks for flake8 checks
- fixes issues highlighted by flake8
