### PR TITLE
Fix GPU.js handling of WebGL

### DIFF
--- a/visualizer/src/Canvas/ComposeCanvases.js
+++ b/visualizer/src/Canvas/ComposeCanvases.js
@@ -1,7 +1,7 @@
 import { makeStyles } from '@material-ui/core';
 import { useSelector } from '@xstate/react';
 import React, { useEffect, useRef } from 'react';
-import { useCanvas } from '../ProjectContext';
+import { useCanvas, useDrawCanvas } from '../ProjectContext';
 
 const useStyles = makeStyles({
   canvas: {
@@ -28,48 +28,32 @@ export const ComposeCanvas = ({ canvases }) => {
   const height = sh * scale * window.devicePixelRatio;
 
   const canvasRef = useRef();
-  const ctxRef = useRef();
-
-  const composeCanvasRef = useRef();
-  const composeCtxRef = useRef();
+  const composeCanvasRef = useDrawCanvas();
 
   useEffect(() => {
-    composeCtxRef.current = composeCanvasRef.current.getContext('2d');
-    composeCtxRef.current.globalCompositeOperation = 'source-over';
-  }, [sh, sw]);
+    composeCanvasRef.current.getContext('2d').globalCompositeOperation = 'source-over';
+  }, [composeCanvasRef]);
 
   useEffect(() => {
-    ctxRef.current = canvasRef.current.getContext('2d');
-    ctxRef.current.imageSmoothingEnabled = false;
+    canvasRef.current.getContext('2d').imageSmoothingEnabled = false;
   }, [height, width]);
 
   useEffect(() => {
-    composeCtxRef.current.clearRect(0, 0, sw, sh);
+    const ctx = composeCanvasRef.current.getContext('2d');
+    ctx.clearRect(0, 0, sw, sh);
     for (let key in canvases) {
-      composeCtxRef.current.drawImage(canvases[key], 0, 0);
+      ctx.drawImage(canvases[key], 0, 0);
     }
-  }, [canvases, sh, sw]);
+  }, [canvases, sh, sw, composeCanvasRef]);
 
   useEffect(() => {
-    ctxRef.current.clearRect(0, 0, width, height);
-    ctxRef.current.drawImage(
-      composeCanvasRef.current,
-      sx,
-      sy,
-      sw / zoom,
-      sh / zoom,
-      0,
-      0,
-      width,
-      height
-    );
-  }, [canvases, sx, sy, sw, sh, zoom, width, height]);
+    const ctx = canvasRef.current.getContext('2d');
+    ctx.clearRect(0, 0, width, height);
+    ctx.drawImage(composeCanvasRef.current, sx, sy, sw / zoom, sh / zoom, 0, 0, width, height);
+  }, [canvases, sx, sy, sw, sh, zoom, width, height, composeCanvasRef]);
 
   return (
-    <>
-      <canvas id='compose-canvas' hidden={true} ref={composeCanvasRef} width={sw} height={sh} />
-      <canvas id='canvas' className={styles.canvas} ref={canvasRef} width={width} height={height} />
-    </>
+    <canvas id='canvas' className={styles.canvas} ref={canvasRef} width={width} height={height} />
   );
 };
 

--- a/visualizer/src/Canvas/Labeled/LabeledCanvas.js
+++ b/visualizer/src/Canvas/Labeled/LabeledCanvas.js
@@ -80,7 +80,7 @@ export const LabeledCanvas = ({ setCanvases }) => {
     drawCtx.drawImage(kernelCanvasRef.current, 0, 0);
     // Rerender the parent canvas with the kernel output
     setCanvases((canvases) => ({ ...canvases, labeled: drawCanvasRef.current }));
-  }, [labeledArray, colormap, foreground, highlight, opacity, setCanvases]);
+  }, [labeledArray, colormap, foreground, highlight, opacity, setCanvases, width, height]);
 
   return null;
 };

--- a/visualizer/src/Canvas/Raw/RGBCanvas.js
+++ b/visualizer/src/Canvas/Raw/RGBCanvas.js
@@ -1,42 +1,34 @@
 import { useSelector } from '@xstate/react';
-import React, { useEffect, useRef, useState } from 'react';
-import { useCanvas, useLayers } from '../../ProjectContext';
+import React, { useEffect, useState } from 'react';
+import { useCanvas, useDrawCanvas, useLayers } from '../../ProjectContext';
 import ChannelCanvas from './ChannelCanvas';
 
 export const RGBCanvas = ({ setCanvases }) => {
   const canvas = useCanvas();
-  const sw = useSelector(canvas, (state) => state.context.width);
-  const sh = useSelector(canvas, (state) => state.context.height);
+  const width = useSelector(canvas, (state) => state.context.width);
+  const height = useSelector(canvas, (state) => state.context.height);
 
   const layers = useLayers();
-
   // keys: layer index, values: ref to canvas for each layer
   const [layerCanvases, setLayerCanvases] = useState({});
-
-  const composeCanvasRef = useRef();
-  const composeCtxRef = useRef();
+  const canvasRef = useDrawCanvas();
 
   useEffect(() => {
-    composeCtxRef.current = composeCanvasRef.current.getContext('2d');
-    composeCtxRef.current.globalCompositeOperation = 'lighter';
-  }, [sh, sw]);
+    canvasRef.current.getContext('2d').globalCompositeOperation = 'lighter';
+  }, [canvasRef]);
 
   useEffect(() => {
-    composeCtxRef.current.clearRect(0, 0, sw, sh);
+    const ctx = canvasRef.current.getContext('2d');
+    ctx.clearRect(0, 0, width, height);
     for (let key in layerCanvases) {
-      composeCtxRef.current.drawImage(layerCanvases[key], 0, 0);
+      ctx.drawImage(layerCanvases[key], 0, 0);
     }
-    setCanvases((canvases) => ({ ...canvases, raw: composeCanvasRef.current }));
-  }, [layerCanvases, sh, sw, setCanvases]);
+    setCanvases((canvases) => ({ ...canvases, raw: canvasRef.current }));
+  }, [layerCanvases, width, height, setCanvases, canvasRef]);
 
-  return (
-    <>
-      <canvas id='compose-layers' hidden={true} ref={composeCanvasRef} width={sw} height={sh} />
-      {layers.map((layer) => (
-        <ChannelCanvas layer={layer} setCanvases={setLayerCanvases} key={layer.sessionId} />
-      ))}
-    </>
-  );
+  return layers.map((layer) => (
+    <ChannelCanvas layer={layer} setCanvases={setLayerCanvases} key={layer.sessionId} />
+  ));
 };
 
 export default RGBCanvas;

--- a/visualizer/src/Canvas/Tool/ThresholdCanvas.js
+++ b/visualizer/src/Canvas/Tool/ThresholdCanvas.js
@@ -85,7 +85,7 @@ const ThresholdCanvas = ({ setCanvases }) => {
         return { ...canvases };
       });
     }
-  }, [setCanvases, show, x1, y1, x2, y2]);
+  }, [setCanvases, show, x1, y1, x2, y2, width, height]);
 
   return null;
 };

--- a/visualizer/src/Canvas/Tool/ThresholdCanvas.js
+++ b/visualizer/src/Canvas/Tool/ThresholdCanvas.js
@@ -1,10 +1,7 @@
 import { useSelector } from '@xstate/react';
 import { GPU } from 'gpu.js';
 import { useEffect, useRef } from 'react';
-import { useCanvas, useThreshold } from '../../ProjectContext';
-
-const gl2 = document.createElement('canvas').getContext('webgl2');
-const gl = document.createElement('canvas').getContext('webgl');
+import { useAlphaKernelCanvas, useCanvas, useDrawCanvas, useThreshold } from '../../ProjectContext';
 
 const ThresholdCanvas = ({ setCanvases }) => {
   const canvas = useCanvas();
@@ -18,25 +15,11 @@ const ThresholdCanvas = ({ setCanvases }) => {
   const show = useSelector(threshold, (state) => state.matches('dragging'));
 
   const kernelRef = useRef();
-  const canvasRef = useRef();
-  const kernelCanvasRef = useRef();
-  const drawCanvasRef = useRef();
+  const kernelCanvasRef = useAlphaKernelCanvas();
+  const drawCanvasRef = useDrawCanvas();
 
   useEffect(() => {
-    kernelCanvasRef.current = document.createElement('canvas');
-    drawCanvasRef.current = document.createElement('canvas');
-    drawCanvasRef.current.width = width;
-    drawCanvasRef.current.height = height;
-  }, [height, width]);
-
-  useEffect(() => {
-    const canvas = kernelCanvasRef.current;
-    if (gl2) {
-      canvas.getContext('webgl2', { premultipliedAlpha: false });
-    } else if (gl) {
-      canvas.getContext('webgl', { premultipliedAlpha: false });
-    }
-    const gpu = new GPU({ canvas });
+    const gpu = new GPU({ canvas: kernelCanvasRef.current });
     const kernel = gpu.createKernel(
       function (x1, y1, x2, y2) {
         const x = this.thread.x;
@@ -66,7 +49,7 @@ const ThresholdCanvas = ({ setCanvases }) => {
       kernel.destroy();
       gpu.destroy();
     };
-  }, [width, height]);
+  }, [kernelCanvasRef, width, height]);
 
   useEffect(() => {
     if (show) {
@@ -85,7 +68,7 @@ const ThresholdCanvas = ({ setCanvases }) => {
         return { ...canvases };
       });
     }
-  }, [setCanvases, show, x1, y1, x2, y2, width, height]);
+  }, [setCanvases, show, x1, y1, x2, y2, kernelCanvasRef, drawCanvasRef, width, height]);
 
   return null;
 };

--- a/visualizer/src/ProjectContext.js
+++ b/visualizer/src/ProjectContext.js
@@ -138,7 +138,7 @@ export function useComposeLayers() {
   useEffect(() => {
     const canvas = canvasRef.current;
     const ctx = canvas.getContext('2d');
-    ctx.globalCompositeOperation = 'lighter';
+    ctx.globalCompositeOperation = 'source-over';
     ctxRef.current = ctx;
   }, [height, width]);
 

--- a/visualizer/src/ProjectContext.js
+++ b/visualizer/src/ProjectContext.js
@@ -205,6 +205,44 @@ export function useThreshold() {
   return tool;
 }
 
+const gl2 = !!document.createElement('canvas').getContext('webgl2');
+const gl = !!document.createElement('canvas').getContext('webgl');
+
+/** Creates a reference to a canvas with an alpha channel to use with a GPU.js kernel. */
+export function useAlphaKernelCanvas() {
+  const canvasRef = useRef();
+
+  useEffect(() => {
+    const canvas = document.createElement('canvas');
+    if (gl2) {
+      canvas.getContext('webgl2', { premultipliedAlpha: false });
+    } else if (gl) {
+      canvas.getContext('webgl', { premultipliedAlpha: false });
+    }
+    canvasRef.current = canvas;
+  }, []);
+
+  return canvasRef;
+}
+
+/** Creates a references to a canvas with the same dimensions as the project. */
+export function useDrawCanvas() {
+  const canvasRef = useRef();
+
+  const canvas = useCanvas();
+  const width = useSelector(canvas, (state) => state.context.width);
+  const height = useSelector(canvas, (state) => state.context.height);
+
+  useEffect(() => {
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    canvasRef.current = canvas;
+  }, [height, width]);
+
+  return canvasRef;
+}
+
 function ProjectContext({ project, children }) {
   return <Context.Provider value={project}>{children}</Context.Provider>;
 }


### PR DESCRIPTION
With the most recent pull request #294, I noticed that Firefox and Chrome handled the new canvas as expected, but Safari was not behaving correctly. It seems that that Safari only received WebGL2 support in Safari 15 released a few months ago with macOS 15: [https://caniuse.com/webgl2](https://caniuse.com/webgl2).

I fixed the initialization of the GPU-accelerated contexts to check which context is available in the browser and set one or the other up as needed. I also had issues with the WebGL canvases clearing their data after being drawn, causing it to appear once and then to appear blank in later renders. To fix this, I drew the WebGL kernel output onto a separate canvas as soon as it is created, and this other canvas with a standard 2d context does not get cleared when drawn. This strategy works just as well for WebGL2, WebGL and canvas based kernels, so I implemented it as the standard approach regardless of WebGL support