### PR TITLE
Fixes for tracking before release

### DIFF
--- a/visualizer/src/Controls/FrameSlider.js
+++ b/visualizer/src/Controls/FrameSlider.js
@@ -1,8 +1,8 @@
-import { makeStyles, Slider, Tooltip } from '@material-ui/core';
+import { FormLabel, makeStyles, Slider, Tooltip } from '@material-ui/core';
 import { useSelector } from '@xstate/react';
 import { bind, unbind } from 'mousetrap';
 import React, { useEffect, useState } from 'react';
-import { useImage } from '../../ProjectContext';
+import { useImage } from '../ProjectContext';
 
 const useStyles = makeStyles((theme) => ({
   title: {
@@ -11,7 +11,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function FrameSlider() {
+function FrameSlider({ showLabel = true }) {
   const image = useImage();
   const frame = useSelector(image, (state) => state.context.frame);
   const numFrames = useSelector(image, (state) => state.context.numFrames);
@@ -52,17 +52,20 @@ function FrameSlider() {
 
   return (
     numFrames > 1 && (
-      <Tooltip title={tooltipText}>
-        <Slider
-          value={frame}
-          valueLabelDisplay={display}
-          step={1}
-          marks
-          min={0}
-          max={numFrames - 1}
-          onChange={handleFrameChange}
-        />
-      </Tooltip>
+      <>
+        {showLabel && <FormLabel>Frame</FormLabel>}
+        <Tooltip title={tooltipText}>
+          <Slider
+            value={frame}
+            valueLabelDisplay={display}
+            step={1}
+            marks
+            min={0}
+            max={numFrames - 1}
+            onChange={handleFrameChange}
+          />
+        </Tooltip>
+      </>
     )
   );
 }

--- a/visualizer/src/Controls/ImageControls/ImageControls.js
+++ b/visualizer/src/Controls/ImageControls/ImageControls.js
@@ -3,7 +3,6 @@ import { green } from '@material-ui/core/colors';
 import React from 'react';
 import { useLabeled, useRaw } from '../../ProjectContext';
 import DownloadButton from './DownloadButton';
-import FrameSlider from './FrameSlider';
 import LabeledControls from './LabeledControls/LabeledControls';
 import RawControls from './RawControls/RawControls';
 import SubmitButton from './SubmitButton';
@@ -49,7 +48,6 @@ const ImageControls = () => {
       ) : (
         <SubmitButton className={styles.buttons} />
       )}
-      <FrameSlider />
       {labeled && <LabeledControls />}
       {raw && <RawControls />}
     </Box>

--- a/visualizer/src/Controls/Segment/SelectedPalette.js
+++ b/visualizer/src/Controls/Segment/SelectedPalette.js
@@ -10,16 +10,7 @@ import SubdirectoryArrowRightIcon from '@material-ui/icons/SubdirectoryArrowRigh
 import { useSelector } from '@xstate/react';
 import { bind } from 'mousetrap';
 import React, { useEffect, useState } from 'react';
-import { useFeature, useLabeled, useSelect } from '../../ProjectContext';
-
-function componentToHex(c) {
-  var hex = c.toString(16);
-  return hex.length === 1 ? '0' + hex : hex;
-}
-
-function rgbToHex(rgb) {
-  return '#' + componentToHex(rgb[0]) + componentToHex(rgb[1]) + componentToHex(rgb[2]);
-}
+import { useHexColormap, useSelect } from '../../ProjectContext';
 
 // adapted from https://stackoverflow.com/questions/9733288/how-to-programmatically-calculate-the-contrast-ratio-between-two-colors
 
@@ -165,11 +156,8 @@ function HoveringBox() {
 
   const styles = useStyles();
 
-  const labeled = useLabeled();
-  const featureIndex = useSelector(labeled, (state) => state.context.feature);
-  const feature = useFeature(featureIndex);
-  const colormap = useSelector(feature, (state) => state.context.colormap);
-  const color = hovering ? rgbToHex(colormap[hovering]) : '#000000';
+  const colormap = useHexColormap();
+  const color = hovering ? colormap[hovering] : '#000000';
 
   const buttonColor =
     contrast(color, '#000000') > contrast(color, '#FFFFFF') ? '#000000' : '#FFFFFF';
@@ -197,11 +185,8 @@ function ForegroundBox() {
 
   const styles = useStyles();
 
-  const labeled = useLabeled();
-  const featureIndex = useSelector(labeled, (state) => state.context.feature);
-  const feature = useFeature(featureIndex);
-  const colormap = useSelector(feature, (state) => state.context.colormap);
-  const color = rgbToHex(colormap[foreground]) ?? '#000000';
+  const colormap = useHexColormap();
+  const color = colormap[foreground] ?? '#000000';
 
   useEffect(() => {
     bind('n', () => select.send('NEW_FOREGROUND'));
@@ -308,11 +293,8 @@ function BackgroundBox() {
 
   const styles = useStyles();
 
-  const labeled = useLabeled();
-  const featureIndex = useSelector(labeled, (state) => state.context.feature);
-  const feature = useFeature(featureIndex);
-  const colormap = useSelector(feature, (state) => state.context.colormap);
-  const color = rgbToHex(colormap[background]) ?? '#000000';
+  const colormap = useHexColormap();
+  const color = colormap[background] ?? '#000000';
 
   useEffect(() => {
     bind('{', () => select.send('PREV_BACKGROUND'));

--- a/visualizer/src/Controls/SegmentControls.js
+++ b/visualizer/src/Controls/SegmentControls.js
@@ -1,0 +1,26 @@
+import Box from '@material-ui/core/Box';
+import { useLabeled } from '../ProjectContext';
+import FrameSlider from './FrameSlider';
+import ActionButtons from './Segment/ActionButtons';
+import SelectedPalette from './Segment/SelectedPalette';
+import ToolButtons from './Segment/ToolButtons';
+import UndoRedo from './Segment/UndoRedo';
+
+function SegmentControls() {
+  const labeled = useLabeled();
+  return (
+    <Box display='flex' flexDirection='column'>
+      <UndoRedo />
+      <FrameSlider />
+      <Box display='flex' flexDirection='row'>
+        <Box display='flex' flexDirection='column'>
+          <ToolButtons />
+          <ActionButtons />
+        </Box>
+        {labeled && <SelectedPalette />}
+      </Box>
+    </Box>
+  );
+}
+
+export default SegmentControls;

--- a/visualizer/src/Controls/Tracking/Division.js
+++ b/visualizer/src/Controls/Tracking/Division.js
@@ -11,15 +11,7 @@ import CloseIcon from '@material-ui/icons/Close';
 import { useSelector } from '@xstate/react';
 import React, { useReducer, useRef } from 'react';
 import { ArcherContainer, ArcherElement } from 'react-archer';
-import { useFeature, useImage, useLabeled, useSelect, useTracking } from '../../ProjectContext';
-
-function useColors() {
-  const labeled = useLabeled();
-  const featureIndex = useSelector(labeled, (state) => state.context.feature);
-  const feature = useFeature(featureIndex);
-  const colors = useSelector(feature, (state) => state.context.colors);
-  return colors;
-}
+import { useHexColormap, useImage, useSelect, useTracking } from '../../ProjectContext';
 
 const useStyles = makeStyles((theme) => ({
   division: {
@@ -49,7 +41,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 export const Cell = React.forwardRef(({ label, onClick }, ref) => {
-  const colors = useColors();
+  const colors = useHexColormap();
   const color = colors[label] ?? '#000000';
 
   const styles = useStyles();

--- a/visualizer/src/Controls/Tracking/LabelTimeline.js
+++ b/visualizer/src/Controls/Tracking/LabelTimeline.js
@@ -1,15 +1,7 @@
 import { Box } from '@material-ui/core';
 import { useSelector } from '@xstate/react';
 import React from 'react';
-import { useDivision, useFeature, useImage, useLabeled } from '../../ProjectContext';
-
-function useColors() {
-  const labeled = useLabeled();
-  const featureIndex = useSelector(labeled, (state) => state.context.feature);
-  const feature = useFeature(featureIndex);
-  const colors = useSelector(feature, (state) => state.context.colors);
-  return colors;
-}
+import { useDivision, useHexColormap, useImage } from '../../ProjectContext';
 
 function FrameBox({ frame, numFrames, color }) {
   const image = useImage();
@@ -36,7 +28,7 @@ function LabelTimeline({ label }) {
   const image = useImage();
   const numFrames = useSelector(image, (state) => state.context.numFrames);
 
-  const colors = useColors();
+  const colors = useHexColormap();
   const division = useDivision(label);
   const { frames } = division;
   const color = colors[label] ?? '#000000';

--- a/visualizer/src/Controls/Tracking/Timeline.js
+++ b/visualizer/src/Controls/Tracking/Timeline.js
@@ -3,8 +3,8 @@ import { useSelector } from '@xstate/react';
 import { bind, unbind } from 'mousetrap';
 import { default as React, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useDivision, useSelect, useTracking } from '../../ProjectContext';
+import FrameSlider from '../FrameSlider';
 import Division, { Cell, DivisionFootprint } from './Division';
-import FrameSlider from './FrameSlider';
 import LabelTimeline from './LabelTimeline';
 
 const useStyles = makeStyles({
@@ -102,7 +102,7 @@ function Timeline() {
       <Divisions label={selected} />
       <FormLabel>Frames</FormLabel>
       <LabelTimeline label={selected} />
-      <FrameSlider />
+      <FrameSlider showLabel={false} />
       <LabelTimeline label={hovering} />
       <FormLabel>Hovering over Label</FormLabel>
       {hovering !== null && <Cell label={hovering} />}

--- a/visualizer/src/Controls/TrackingControls.js
+++ b/visualizer/src/Controls/TrackingControls.js
@@ -1,0 +1,17 @@
+import { useLabeled } from '../ProjectContext';
+import UndoRedo from './Segment/UndoRedo';
+import DivisionAlerts from './Tracking/Alerts/DivisionAlerts';
+import Timeline from './Tracking/Timeline';
+
+function TrackingControls() {
+  const labeled = useLabeled();
+  return (
+    <>
+      <UndoRedo />
+      <DivisionAlerts />
+      {labeled && <Timeline />}
+    </>
+  );
+}
+
+export default TrackingControls;

--- a/visualizer/src/Label.js
+++ b/visualizer/src/Label.js
@@ -1,4 +1,4 @@
-import { FormLabel, Paper, Tab, Tabs } from '@material-ui/core';
+import { Paper, Tab, Tabs } from '@material-ui/core';
 import Box from '@material-ui/core/Box';
 import { makeStyles } from '@material-ui/core/styles';
 import { useSelector } from '@xstate/react';
@@ -8,15 +8,10 @@ import { useEffect, useRef, useState } from 'react';
 import Canvas from './Canvas/Canvas';
 import ImageControls from './Controls/ImageControls/ImageControls';
 import QCControls from './Controls/QCControls';
-import ActionButtons from './Controls/Segment/ActionButtons';
-import SelectedPalette from './Controls/Segment/SelectedPalette';
-import ToolButtons from './Controls/Segment/ToolButtons';
-import UndoRedo from './Controls/Segment/UndoRedo';
-import DivisionAlerts from './Controls/Tracking/Alerts/DivisionAlerts';
-import FrameSlider from './Controls/Tracking/FrameSlider';
-import Timeline from './Controls/Tracking/Timeline';
+import SegmentControls from './Controls/SegmentControls';
+import TrackingControls from './Controls/TrackingControls';
 import Instructions from './Instructions/Instructions';
-import { useCanvas, useLabeled, useLabelMode } from './ProjectContext';
+import { useCanvas, useLabelMode } from './ProjectContext';
 
 const useStyles = makeStyles((theme) => ({
   main: {
@@ -73,8 +68,6 @@ function Label({ review }) {
 
   const labelMode = useLabelMode();
   const canvas = useCanvas();
-  const labeled = useLabeled();
-
   const value = useSelector(labelMode, (state) => {
     return state.matches('segment') ? 0 : state.matches('track') ? 1 : false;
   });
@@ -136,23 +129,10 @@ function Label({ review }) {
         </Box>
         <Box className={styles.toolbarBox}>
           <TabPanel value={value} index={0}>
-            <Box display='flex' flexDirection='column'>
-              <UndoRedo />
-              <FormLabel>Frame</FormLabel>
-              <FrameSlider />
-              <Box display='flex' flexDirection='row'>
-                <Box display='flex' flexDirection='column'>
-                  <ToolButtons />
-                  <ActionButtons />
-                </Box>
-                {labeled && <SelectedPalette />}
-              </Box>
-            </Box>
+            <SegmentControls />
           </TabPanel>
           <TabPanel value={value} index={1}>
-            <UndoRedo />
-            <DivisionAlerts />
-            {labeled && <Timeline />}
+            <TrackingControls />
           </TabPanel>
         </Box>
         <Box ref={canvasBoxRef} className={styles.canvasBox}>

--- a/visualizer/src/Load/FileUpload.js
+++ b/visualizer/src/Load/FileUpload.js
@@ -93,7 +93,7 @@ export default function FileUpload({ loadService }) {
       <Dropzone
         name='imageUploadInput'
         onDrop={(files) => send({ type: 'SET_UPLOAD_FILE', files })}
-        accept='image/png, image/tiff, .npz'
+        accept='image/png, image/tiff, .npz, .trk'
       >
         {({ getRootProps, getInputProps, fileRejections }) => (
           <section>

--- a/visualizer/src/ProjectContext.js
+++ b/visualizer/src/ProjectContext.js
@@ -205,6 +205,23 @@ export function useThreshold() {
   return tool;
 }
 
+function componentToHex(c) {
+  var hex = c.toString(16);
+  return hex.length === 1 ? '0' + hex : hex;
+}
+
+function rgbToHex(rgb) {
+  return '#' + componentToHex(rgb[0]) + componentToHex(rgb[1]) + componentToHex(rgb[2]);
+}
+
+export function useHexColormap() {
+  const labeled = useLabeled();
+  const featureIndex = useSelector(labeled, (state) => state.context.feature);
+  const feature = useFeature(featureIndex);
+  const colormap = useSelector(feature, (state) => state.context.colormap);
+  return colormap.map(rgbToHex);
+}
+
 function ProjectContext({ project, children }) {
   return <Context.Provider value={project}>{children}</Context.Provider>;
 }

--- a/visualizer/src/index.tsx
+++ b/visualizer/src/index.tsx
@@ -1,29 +1,12 @@
-import { grey } from '@material-ui/core/colors';
-import { createMuiTheme } from '@material-ui/core/styles';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from './App';
 import './index.css';
 import reportWebVitals from './reportWebVitals';
 
-const darkTheme = createMuiTheme({
-  palette: {
-    type: 'dark',
-    primary: grey,
-    secondary: grey,
-  },
-  props: {
-    MuiButtonBase: {
-      disableRipple: true,
-    },
-  },
-});
-
 ReactDOM.render(
   <React.StrictMode>
-    {/* <ThemeProvider theme={darkTheme}> */}
     <App />
-    {/* </ThemeProvider> */}
   </React.StrictMode>,
   document.getElementById('root')
 );


### PR DESCRIPTION
This adds in a couple of fixes, mostly for tracking jobs, including

- enabling uploading .trk from the homepage
- removing an extra FrameSlider above the image controls
- hiding the Frame label when FrameSlider is hidden
- fixing the colors provided to the Division components to be provided in hex format instead of a list of [r, g, b]