### PR TITLE
Fix canvas states for changing cursor

### DIFF
--- a/visualizer/src/Canvas/Canvas.js
+++ b/visualizer/src/Canvas/Canvas.js
@@ -31,11 +31,9 @@ export const Canvas = () => {
   const sh = useSelector(canvas, (state) => state.context.height);
   const scale = useSelector(canvas, (state) => state.context.scale);
 
-  const grab = useSelector(canvas, (state) => state.matches('pan.grab'));
-  const grabbing = useSelector(canvas, (state) => state.matches('pan.grab.panning'));
-  const dragged = useSelector(canvas, (state) =>
-    state.matches('pan.interactive.panOnDrag.dragged')
-  );
+  const grab = useSelector(canvas, (state) => state.matches('grab'));
+  const grabbing = useSelector(canvas, (state) => state.matches('grab.panning'));
+  const dragged = useSelector(canvas, (state) => state.matches('interactive.panOnDrag.dragged'));
   const cursor = grabbing || dragged ? 'grabbing' : grab ? 'grab' : 'crosshair';
 
   const segment = useSegment();


### PR DESCRIPTION
After changing the canvas in #294 to be easier to mock, the states changes slightly but were not updated in the Canvas component, so the cursor does not change to a grabbing hand as before. This updates the state names in the component.