### PR TITLE
Remove node 12 from testing matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [14.x, 16.x, 17.x]
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Our frontend testing suite has started failing on the yarn install step because Node 12 has reached its end of life. This PR drops node 12 from the testing matrix.