### PR TITLE
Set file upload size limit to 50 megabytes

### DIFF
--- a/.ebextensions/files.config
+++ b/.ebextensions/files.config
@@ -1,0 +1,7 @@
+files:
+  "/etc/nginx/conf.d/proxy.conf" :
+    mode: "000755"
+    owner: root
+    group: root
+    content: |
+      client_max_body_size 50M;

--- a/.ebextensions/files.config
+++ b/.ebextensions/files.config
@@ -1,7 +1,0 @@
-files:
-  "/etc/nginx/conf.d/proxy.conf" :
-    mode: "000755"
-    owner: root
-    group: root
-    content: |
-      client_max_body_size 50M;

--- a/.platform/nginx/conf.d/proxy.conf
+++ b/.platform/nginx/conf.d/proxy.conf
@@ -1,0 +1,1 @@
+client_max_body_size 50M;


### PR DESCRIPTION
As reported in #305, drag and drop is not working on the label.deepcell.org homepage due to the 413 errors reporting that attached files are too large.

I believe with our update to Amazon Linux 2 for the backend in #287, the behavior for nginx changed. With this new platform, the configuration looks a bit different/ With the previous platform, we would [set up this file with a `.config` file ](https://stackoverflow.com/questions/18908426/increasing-client-max-body-size-in-nginx-conf-on-aws-elastic-beanstalk) but with Amazon Linux 2, [this approach no longer works ](https://stackoverflow.com/a/70959127/14458070) and instead we put the conf file in the `.platform` folder.