### PR TITLE
Add imagecodecs to requirements

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Cache node_modules
         uses: actions/cache@v2
         with:
-          path: 'visualizer/**/node_modules'
+          path: "visualizer/**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('visualizer/**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
@@ -60,7 +60,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_stages: [commit]
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.3.0
     hooks:
       - id: black
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ flask-cors~=3.0.10
 flask-dropzone~=1.6.0
 flask-monitoringdashboard~=3.1.1
 flask-sqlalchemy~=2.5.1
+imagecodecs~=2022.2.22
 matplotlib~=3.5.0
 mysqlclient~=2.1.0
 numpy~=1.21.4


### PR DESCRIPTION
I have been seeing this error come up in the backend logs when users try to load tiffs from the Label homepage.
```
ValueError: <COMPRESSION.LZW: 5> requires the 'imagecodecs' package
```

This adds imagecodecs to the requirements for the backend. It also drops Python 3.7 from our testing matrix as the latest release of imagecodecs is for Python 3.8+ per this NEP (like PEP for numpy) https://numpy.org/neps/nep-0029-deprecation_policy.html. We now use Python 3.8 for hosting on Elastic Beanstalk, so this matches our use.