### PR TITLE
Fix loading from deepcell.org/predict

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Cache pip
         uses: actions/cache@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim-bullseye as base
+FROM python:3.8-slim-bullseye as base
 
 FROM base as builder
 
@@ -11,11 +11,11 @@ COPY requirements.txt requirements-test.txt ./
 # Installation on Python3.8+ may require
 # pkg-config libfreetype6-dev libxft-dev libpng-dev
 RUN apt-get update && apt-get install -y \
-    build-essential default-libmysqlclient-dev && \
-    rm -rf /var/lib/apt/lists/*
+  build-essential default-libmysqlclient-dev && \
+  rm -rf /var/lib/apt/lists/*
 
 RUN pip install --prefix=/install --no-cache-dir \
-    -r requirements.txt gunicorn
+  -r requirements.txt gunicorn
 
 FROM base
 

--- a/deepcell_label/export.py
+++ b/deepcell_label/export.py
@@ -122,7 +122,7 @@ def rewrite_labeled(labeled, cells):
     (f, duration, height, width) = labeled.shape
     new_cells = []
     for t in range(duration):
-        cells_at_t = list(filter(lambda c: c['t'] == t, cells))
+        cells_at_t = list(filter(lambda c, t=t: c['t'] == t, cells))
         values = itertools.groupby(cells_at_t, lambda c: c['value'])
         overlap_values = []
 

--- a/deepcell_label/loaders.py
+++ b/deepcell_label/loaders.py
@@ -474,15 +474,8 @@ def load_tiff(f, axes=None):
             elif axes == 'XYB':
                 X = np.moveaxis(X, -1, 0)
                 return X[..., np.newaxis]
-            else:  # Treat smallest axis as channels
-                print(
-                    f'Warning: tiff with shape {X.shape} has 3 dimensions '
-                    f'with unsupported axes {axes}. '
-                    'Using smallest axis as channels.'
-                )
-                smallest_axis = np.argmin(X.shape)
-                X = np.moveaxis(X, smallest_axis, -1)
-                return X[np.newaxis, ...]
+            else:  # Add channel axis
+                return X[..., np.newaxis]
         elif X.ndim == 4:
             if axes == 'BXYC':
                 return X

--- a/deepcell_label/loaders.py
+++ b/deepcell_label/loaders.py
@@ -319,7 +319,7 @@ def load_zip_tiffs(zf, filename):
                 ]
                 batches[batch] = np.stack(features, axis=-1)
             # Stack batches on first axis
-            batches = map(lambda x: x[1][0], sorted(batches.items()))
+            batches = map(lambda x: x[1], sorted(batches.items()))
             array = np.stack(batches, axis=0)
             return array
         else:  # Use each tiff as a channel and stack on the last axis

--- a/deepcell_label/loaders_test.py
+++ b/deepcell_label/loaders_test.py
@@ -213,9 +213,9 @@ def test_load_batches():
 
         with zipfile.ZipFile(labels, mode='w') as zf:
             with zf.open('batch_0_feature_0.tiff', 'w') as tiff:
-                tiff.write(make_tiff(np.zeros((1, 100, 100))))
+                tiff.write(make_tiff(np.zeros((100, 100))))
             with zf.open('batch_1_feature_0.tiff', 'w') as tiff:
-                tiff.write(make_tiff(np.zeros((1, 100, 100)) + 1))
+                tiff.write(make_tiff(np.zeros((100, 100)) + 1))
         labels.seek(0)
 
         loader = Loader(images, labels, 'BYXC')

--- a/documentation/FIRST_TIME_SETUP.md
+++ b/documentation/FIRST_TIME_SETUP.md
@@ -14,7 +14,7 @@ If the command fails, install Python with Anaconda by following the installation
 
 ### Create a Python virtual environment
 
-We recommend installing Python dependencies in a virtual environment isolate the project from the rest of your machine. If you're using Anaconda, create a virtual environment named `deepcell-label` with this command: `conda create -n deepcell-label python=3.7`.
+We recommend installing Python dependencies in a virtual environment isolate the project from the rest of your machine. If you're using Anaconda, create a virtual environment named `deepcell-label` with this command: `conda create -n deepcell-label python=3.8`.
 
 Then activate the virtual environment with: `conda activate deepcell-label`.
 


### PR DESCRIPTION
This addresses some quick fixes for loading from deepcell.org/predict (now online!). 

The first issue was from an incorrect test case that caused loading zips of tiffs with batches to drop the X dimension.
The second issue was assuming the smallest dimension is the channels when axes are not provided, causing tracking timelapses to use their time axis as channels instead.