### PR TITLE
Add python-magic-bin

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,6 +13,7 @@ pillow~=8.4.0
 python-decouple~=3.1
 python-dotenv~=0.19.2
 python-magic~=0.4.25
+python-magic-bin~=0.4.14
 requests~=2.26.0
 scikit-image~=0.19.0
 sqlalchemy~=1.3.24

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -13,7 +13,6 @@ pillow~=8.4.0
 python-decouple~=3.1
 python-dotenv~=0.19.2
 python-magic~=0.4.25
-python-magic-bin~=0.4.14
 requests~=2.26.0
 scikit-image~=0.19.0
 sqlalchemy~=1.3.24

--- a/documentation/FIRST_TIME_SETUP.md
+++ b/documentation/FIRST_TIME_SETUP.md
@@ -1,6 +1,6 @@
 # First Time Setup Guide
 
-This instructions install Python and Node on your machine. If you've worked with Python or Javascript projects on your machine, skip this instructions and proceed with the README. DeepCell Label has been developed for Unix based systems, but it should work on Windows as well.
+This instructions install Python and Node on your machine. If you've worked with Python or Javascript projects on your machine, skip this instructions and proceed with the README. DeepCell Label has been developed for Unix based systems, but it should work on Windows as well. You may need to install python-magic-bin in your Python environment if working on Windows.
 
 ## Set up Python
 


### PR DESCRIPTION
When setting up the deepcell label repository with Kevin Yu this week, our incoming schmidt software engineer, there was an issue with using python-magic on windows. Installing python-magic-bin as a python dependency solved the issue.