### PR TITLE
Run tests when pushing to main

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -3,7 +3,11 @@
 
 name: tests
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   e2e-tests:


### PR DESCRIPTION
When merging into main for the 0.4 release, the tests didn't run. This gets the tests GitHub Action to run when pushing to main. Coverage for coveralls is based on tests on main, so this will keep the coverage badge up to date.