### PR TITLE
Fix bug causing segmentations to be lost upon reload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,5 +161,6 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 package-lock.json
+package.json
 
 .nyc_output

--- a/backend/deepcell_label/blueprints.py
+++ b/backend/deepcell_label/blueprints.py
@@ -5,6 +5,8 @@ import io
 import tempfile
 import timeit
 import traceback
+import os
+import platform
 
 import boto3
 import requests
@@ -115,12 +117,16 @@ def create_project_from_dropped_file():
     """
     start = timeit.default_timer()
     input_file = request.files.get('images')
+    delete_temp = False if platform.system() == 'Windows' else True
     # axes = request.form['axes'] if 'axes' in request.form else DCL_AXES
-    with tempfile.NamedTemporaryFile() as f:
+    with tempfile.NamedTemporaryFile(delete=delete_temp) as f:
         f.write(input_file.read())
         f.seek(0)
         loader = Loader(f)
         project = Project.create(loader)
+    if not delete_temp:
+        f.close()
+        os.remove(f.name)   # Manually close and delete if using Windows
     current_app.logger.info(
         'Created project %s from %s in %s s.',
         project.project,

--- a/backend/deepcell_label/blueprints.py
+++ b/backend/deepcell_label/blueprints.py
@@ -75,7 +75,9 @@ def create_project():
         )
     labels_url = request.form['labels'] if 'labels' in request.form else None
     axes = request.form['axes'] if 'axes' in request.form else None
-    with tempfile.NamedTemporaryFile(delete=DELETE_TEMP) as image_file, tempfile.NamedTemporaryFile(delete=DELETE_TEMP) as label_file:
+    with tempfile.NamedTemporaryFile(
+        delete=DELETE_TEMP
+    ) as image_file, tempfile.NamedTemporaryFile(delete=DELETE_TEMP) as label_file:
         if images_url is not None:
             image_response = requests.get(images_url)
             if image_response.status_code != 200:

--- a/backend/deepcell_label/blueprints.py
+++ b/backend/deepcell_label/blueprints.py
@@ -6,14 +6,13 @@ import tempfile
 import timeit
 import traceback
 import os
-import platform
 
 import boto3
 import requests
 from flask import Blueprint, abort, current_app, jsonify, request, send_file
 from werkzeug.exceptions import HTTPException
 
-from deepcell_label.config import AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
+from deepcell_label.config import AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, DELETE_TEMP
 from deepcell_label.export import Export
 from deepcell_label.label import Edit
 from deepcell_label.loaders import Loader
@@ -117,14 +116,13 @@ def create_project_from_dropped_file():
     """
     start = timeit.default_timer()
     input_file = request.files.get('images')
-    delete_temp = False if platform.system() == 'Windows' else True
     # axes = request.form['axes'] if 'axes' in request.form else DCL_AXES
-    with tempfile.NamedTemporaryFile(delete=delete_temp) as f:
+    with tempfile.NamedTemporaryFile(delete=DELETE_TEMP) as f:
         f.write(input_file.read())
         f.seek(0)
         loader = Loader(f)
         project = Project.create(loader)
-    if not delete_temp:
+    if not DELETE_TEMP:
         f.close()
         os.remove(f.name)   # Manually close and delete if using Windows
     current_app.logger.info(

--- a/backend/deepcell_label/config.py
+++ b/backend/deepcell_label/config.py
@@ -1,6 +1,7 @@
 """Configuration options and environment variables."""
 from __future__ import absolute_import, division, print_function
 
+import platform
 from decouple import config
 
 DEBUG = config('DEBUG', cast=bool, default=True)
@@ -40,3 +41,5 @@ COMPRESS_MIMETYPES = [
 COMPRESS_LEVEL = 6
 COMPRESS_MIN_SIZE = 500
 COMPRESS_ALGORITHM = 'gzip'
+
+DELETE_TEMP = platform.system() != 'Windows'

--- a/backend/deepcell_label/conftest.py
+++ b/backend/deepcell_label/conftest.py
@@ -28,7 +28,9 @@ class DummyLoader(Loader):
             super().__init__(images, labels)
         if not DELETE_TEMP:
             images.close()
+            labels.close()
             os.remove(images.name)
+            os.remove(labels.name)
 
     # Prevent changing mocked data
     @property

--- a/backend/deepcell_label/conftest.py
+++ b/backend/deepcell_label/conftest.py
@@ -2,7 +2,6 @@
 
 import os
 import tempfile
-import platform
 
 import numpy as np
 import pytest
@@ -10,6 +9,7 @@ from flask_sqlalchemy import SQLAlchemy
 
 from deepcell_label import create_app  # pylint: disable=C0413
 from deepcell_label.loaders import Loader
+from deepcell_label.config import DELETE_TEMP
 
 # flask-sqlalchemy fixtures from http://alexmic.net/flask-sqlalchemy-pytest/
 
@@ -24,10 +24,9 @@ class DummyLoader(Loader):
         self._X = X if X is not None else np.zeros((1, 1, 1, 1))
         self._y = y if y is not None else np.zeros(self._X.shape)
         self._spots = spots
-        delete_temp = False if platform.system() == 'Windows' else True
-        with tempfile.NamedTemporaryFile(delete=delete_temp) as images, tempfile.NamedTemporaryFile(delete=delete_temp) as labels:
+        with tempfile.NamedTemporaryFile(delete=DELETE_TEMP) as images, tempfile.NamedTemporaryFile(delete=DELETE_TEMP) as labels:
             super().__init__(images, labels)
-        if not delete_temp:
+        if not DELETE_TEMP:
             images.close()
             os.remove(images.name)
 

--- a/backend/deepcell_label/conftest.py
+++ b/backend/deepcell_label/conftest.py
@@ -2,6 +2,7 @@
 
 import os
 import tempfile
+import platform
 
 import numpy as np
 import pytest
@@ -23,8 +24,12 @@ class DummyLoader(Loader):
         self._X = X if X is not None else np.zeros((1, 1, 1, 1))
         self._y = y if y is not None else np.zeros(self._X.shape)
         self._spots = spots
-        with tempfile.NamedTemporaryFile() as images, tempfile.NamedTemporaryFile() as labels:
+        delete_temp = False if platform.system() == 'Windows' else True
+        with tempfile.NamedTemporaryFile(delete=delete_temp) as images, tempfile.NamedTemporaryFile(delete=delete_temp) as labels:
             super().__init__(images, labels)
+        if not delete_temp:
+            images.close()
+            os.remove(images.name)
 
     # Prevent changing mocked data
     @property

--- a/backend/deepcell_label/label.py
+++ b/backend/deepcell_label/label.py
@@ -213,8 +213,7 @@ class Edit(object):
             (numpy array of shape (height, width), cells with updated values)
         """
         values = [cell['value'] for cell in cells]  # get list of values
-        cell_mask = np.in1d(labeled, values)
-        deleted_mask = np.logical_not(cell_mask).reshape(labeled.shape)
+        deleted_mask = np.isin(labeled, values, invert=True)
         labeled[deleted_mask] = 0   # delete any labels not in values
         return labeled
 

--- a/backend/deepcell_label/label.py
+++ b/backend/deepcell_label/label.py
@@ -166,6 +166,7 @@ class Edit(object):
         return mask
 
     def add_mask(self, mask, cell):
+        self.labels = self.clean_labels(self.labels, self.cells)
         if self.write_mode == 'overwrite':
             self.labels[mask] = self.get_value([cell])
         elif self.write_mode == 'exclude':
@@ -198,6 +199,24 @@ class Edit(object):
     def clean_cell(self, cell):
         """Ensures that a cell is a positive integer"""
         return int(max(0, cell))
+
+    def clean_labels(self, labeled, cells):
+        # TODO: does this work with time series right now?
+        """Ensures that labels do not include any values that do not correspond
+           to cells (eg. for deleted cells.)
+
+        Args:
+            labeled: numpy array of shape (height, width)
+            cells: list of cells labels like { "cell": 1, "value": 1, "t": 0}
+
+        Returns:
+            (numpy array of shape (height, width), cells with updated values)
+        """
+        values = [cell['value'] for cell in cells]  # get list of values
+        cell_mask = np.in1d(labeled, values)
+        deleted_mask = np.logical_not(cell_mask).reshape(labeled.shape)
+        labeled[deleted_mask] = 0   # delete any labels not in values
+        return labeled
 
     def dispatch_action(self):
         """

--- a/backend/deepcell_label/label.py
+++ b/backend/deepcell_label/label.py
@@ -201,7 +201,8 @@ class Edit(object):
         return int(max(0, cell))
 
     def clean_labels(self, labeled, cells):
-        """Ensures that labels do not include any values that do not correspond
+        """
+        Ensures that labels do not include any values that do not correspond
            to cells (eg. for deleted cells.)
 
         Args:

--- a/backend/deepcell_label/label_test.py
+++ b/backend/deepcell_label/label_test.py
@@ -267,3 +267,19 @@ class TestEdit:
                 write_mode='exclude',
             )
             np.testing.assert_array_equal(expected_labels, edit.labels)
+
+    def test_clean_labels(self, app):
+        """Tests that labels are properly removed for values with no corresponding cell. """
+        labels = np.array([[1, 1], [2, 2]], dtype=np.int32)
+        expected_labels = np.array([[0, 0], [2, 2]], dtype=np.int32)
+        cells = [{'cell': 1, 'value': 3}, {'cell': 2, 'value': 2}]
+
+        with app.app_context():
+            edit = DummyEdit(
+                labels=labels,
+                cells=cells,
+                action='draw',
+                args={'trace': '[]', 'brush_size': 0, 'cell': 2, 'erase': False},
+                write_mode='exclude'
+            )
+            np.testing.assert_array_equal(edit.labels, expected_labels)

--- a/backend/deepcell_label/loaders_test.py
+++ b/backend/deepcell_label/loaders_test.py
@@ -4,16 +4,16 @@ Tests for loading files in loaders.
 
 import io
 import json
+import os
 import tempfile
 import zipfile
-import os
 
 import numpy as np
 from PIL import Image
 from tifffile import TiffFile, TiffWriter, imwrite
 
-from deepcell_label.loaders import Loader
 from deepcell_label.config import DELETE_TEMP
+from deepcell_label.loaders import Loader
 
 
 def assert_image(archive, expected):

--- a/backend/deepcell_label/loaders_test.py
+++ b/backend/deepcell_label/loaders_test.py
@@ -4,16 +4,16 @@ Tests for loading files in loaders.
 
 import io
 import json
-import os
-import platform
 import tempfile
 import zipfile
+import os
 
 import numpy as np
 from PIL import Image
 from tifffile import TiffFile, TiffWriter, imwrite
 
 from deepcell_label.loaders import Loader
+from deepcell_label.config import DELETE_TEMP
 
 
 def assert_image(archive, expected):
@@ -91,14 +91,13 @@ def test_load_separate_npz():
 def test_load_image_tiff():
     """Load image from tiff file."""
     expected = np.zeros((1, 1, 1, 1))
-    delete_temp = False if platform.system() == 'Windows' else True
-    with tempfile.NamedTemporaryFile(delete=delete_temp) as images:
+    with tempfile.NamedTemporaryFile(delete=DELETE_TEMP) as images:
         with TiffWriter(images) as writer:
             writer.write(expected)
             images.seek(0)
 
         loader = Loader(images)
-    if not delete_temp:
+    if not DELETE_TEMP:
         images.close()
         os.remove(images.name)
 
@@ -130,13 +129,12 @@ def test_load_image_and_segmentation_tiff():
 def test_load_image_png():
     """Load image array from png file."""
     expected = np.zeros((1, 1, 1, 1))
-    delete_temp = False if platform.system() == 'Windows' else True
-    with tempfile.NamedTemporaryFile(delete=delete_temp) as images:
+    with tempfile.NamedTemporaryFile(delete=DELETE_TEMP) as images:
         img = Image.fromarray(np.zeros((1, 1)), mode='L')
         img.save(images, format='png')
         images.seek(0)
         loader = Loader(images)
-    if not delete_temp:
+    if not DELETE_TEMP:
         images.close()
         os.remove(images.name)
     loaded_zip = zipfile.ZipFile(io.BytesIO(loader.data))

--- a/backend/deepcell_label/loaders_test.py
+++ b/backend/deepcell_label/loaders_test.py
@@ -6,6 +6,8 @@ import io
 import json
 import tempfile
 import zipfile
+import platform
+import os
 
 import numpy as np
 from PIL import Image
@@ -89,12 +91,16 @@ def test_load_separate_npz():
 def test_load_image_tiff():
     """Load image from tiff file."""
     expected = np.zeros((1, 1, 1, 1))
-    with tempfile.NamedTemporaryFile() as images:
+    delete_temp = False if platform.system() == 'Windows' else True
+    with tempfile.NamedTemporaryFile(delete=delete_temp) as images:
         with TiffWriter(images) as writer:
             writer.write(expected)
             images.seek(0)
 
         loader = Loader(images)
+    if not delete_temp:
+        images.close()
+        os.remove(images.name)
 
     loaded_zip = zipfile.ZipFile(io.BytesIO(loader.data))
     assert_image(loaded_zip, expected)
@@ -124,11 +130,15 @@ def test_load_image_and_segmentation_tiff():
 def test_load_image_png():
     """Load image array from png file."""
     expected = np.zeros((1, 1, 1, 1))
-    with tempfile.NamedTemporaryFile() as images:
+    delete_temp = False if platform.system() == 'Windows' else True
+    with tempfile.NamedTemporaryFile(delete=delete_temp) as images:
         img = Image.fromarray(np.zeros((1, 1)), mode='L')
         img.save(images, format='png')
         images.seek(0)
         loader = Loader(images)
+    if not delete_temp:
+        images.close()
+        os.remove(images.name)
     loaded_zip = zipfile.ZipFile(io.BytesIO(loader.data))
     assert_image(loaded_zip, expected)
 

--- a/frontend/src/Project/service/idbWebWorker.js
+++ b/frontend/src/Project/service/idbWebWorker.js
@@ -117,9 +117,9 @@ const idbMachine = createMachine(
       setProjectFromDb: assign({ project: (ctx, evt) => ({ ...evt.data }) }),
       updateLabeled: assign({
         project: (ctx, evt) => {
-          const { t, feature } = evt;
+          const { t, c } = evt;
           const labeled = ctx.project.labeled.map((arr, i) =>
-            i === feature ? arr.map((arr, j) => (j === t ? evt.labeled : arr)) : arr
+            i === c ? arr.map((arr, j) => (j === t ? evt.labeled : arr)) : arr
           );
           return { ...ctx.project, labeled };
         },


### PR DESCRIPTION
## What
My guess is that after Tom fixed the bug related to adding c to cells, the "feature" field was renamed to "c", so the idbWebWorker was unable to find what segmentation feature was being edited, and segmentations were thus not being tracked.

## Why
Users can now reload without losing their segmentation changes (eg. brush adds/removes).