### PR TITLE
Fix canvas rendering bugs caused by issues with gpu rendering kernel

### DIFF
--- a/backend/deepcell_label/blueprints.py
+++ b/backend/deepcell_label/blueprints.py
@@ -75,7 +75,9 @@ def create_project():
         )
     labels_url = request.form['labels'] if 'labels' in request.form else None
     axes = request.form['axes'] if 'axes' in request.form else None
-    with tempfile.NamedTemporaryFile(delete=DELETE_TEMP) as image_file, tempfile.NamedTemporaryFile(delete=DELETE_TEMP) as label_file:
+    with tempfile.NamedTemporaryFile(
+        delete=DELETE_TEMP
+    ) as image_file, tempfile.NamedTemporaryFile(delete=DELETE_TEMP) as label_file:
         if images_url is not None:
             image_response = requests.get(images_url)
             if image_response.status_code != 200:

--- a/backend/deepcell_label/config.py
+++ b/backend/deepcell_label/config.py
@@ -43,4 +43,5 @@ COMPRESS_LEVEL = 6
 COMPRESS_MIN_SIZE = 500
 COMPRESS_ALGORITHM = 'gzip'
 
+# Flag for checking operating system
 DELETE_TEMP = platform.system() != 'Windows'

--- a/backend/deepcell_label/label.py
+++ b/backend/deepcell_label/label.py
@@ -201,7 +201,8 @@ class Edit(object):
         return int(max(0, cell))
 
     def clean_labels(self, labeled, cells):
-        """Ensures that labels do not include any values that do not correspond
+        """
+        Ensures that labels do not include any values that do not correspond
            to cells (eg. for deleted cells.)
 
         Args:

--- a/backend/deepcell_label/loaders_test.py
+++ b/backend/deepcell_label/loaders_test.py
@@ -4,16 +4,16 @@ Tests for loading files in loaders.
 
 import io
 import json
+import os
 import tempfile
 import zipfile
-import os
 
 import numpy as np
 from PIL import Image
 from tifffile import TiffFile, TiffWriter, imwrite
 
-from deepcell_label.loaders import Loader
 from deepcell_label.config import DELETE_TEMP
+from deepcell_label.loaders import Loader
 
 
 def assert_image(archive, expected):

--- a/frontend/src/Project/Canvas/LabeledCanvas.js
+++ b/frontend/src/Project/Canvas/LabeledCanvas.js
@@ -73,7 +73,7 @@ export const LabeledCanvas = ({ setBitmaps }) => {
         output: [width, height],
         graphical: true,
         dynamicArguments: true,
-
+        loopMaxIterations: 5000,
       }
     );
     kernelRef.current = kernel;

--- a/frontend/src/Project/Canvas/LabeledCanvas.js
+++ b/frontend/src/Project/Canvas/LabeledCanvas.js
@@ -73,7 +73,7 @@ export const LabeledCanvas = ({ setBitmaps }) => {
         output: [width, height],
         graphical: true,
         dynamicArguments: true,
-        loopMaxIterations: 5000,
+        loopMaxIterations: 5000, // Maximum number of cell labels to render
       }
     );
     kernelRef.current = kernel;

--- a/frontend/src/Project/Canvas/LabeledCanvas.js
+++ b/frontend/src/Project/Canvas/LabeledCanvas.js
@@ -47,15 +47,15 @@ export const LabeledCanvas = ({ setBitmaps }) => {
                 sg = colormap[i][1];
                 sb = colormap[i][2];
               }
-  
+
               if (i !== cell) {
                 a = a * (1 - opacity[0]);
                 sr = opacity[0] * sr / 255;
                 sg = opacity[0] * sg / 255;
                 sb = opacity[0] * sb / 255;
               } else {
-  
-                a = a * (1 - opacity[1]); 
+
+                a = a * (1 - opacity[1]);
                 sr = opacity[1] * sr / 255;
                 sg = opacity[1] * sg / 255;
                 sb = opacity[1] * sb / 255;

--- a/frontend/src/Project/Canvas/OutlineCanvas.js
+++ b/frontend/src/Project/Canvas/OutlineCanvas.js
@@ -94,7 +94,7 @@ const OutlineCanvas = ({ setBitmaps }) => {
         output: [width, height],
         graphical: true,
         dynamicArguments: true,
-        loopMaxIterations: 5000,
+        loopMaxIterations: 5000, // Maximum number of outlines to render
       }
     );
     kernelRef.current = kernel;

--- a/frontend/src/Project/Canvas/OutlineCanvas.js
+++ b/frontend/src/Project/Canvas/OutlineCanvas.js
@@ -69,7 +69,8 @@ const OutlineCanvas = ({ setBitmaps }) => {
         if (value < numValues) {
           for (let i = 0; i < numLabels; i++) {
             if (cells[value][i] === 1) {
-              if (cells[north][i] === 0 || cells[south][i] === 0 || cells[west][i] === 0 || cells[east][i] === 0)
+              if (cells[north][i] === 0 || cells[south][i] === 0 || cells[west][i] === 0 || cells[east][i] === 0
+                  || north >= numValues || south >= numValues || west >= numValues || east >= numValues)
              {
                 if (cell === i) {
                   outlineOpacity = outlineOpacity * (1 - opacity[1]);

--- a/frontend/src/Project/service/idbWebWorker.js
+++ b/frontend/src/Project/service/idbWebWorker.js
@@ -117,9 +117,9 @@ const idbMachine = createMachine(
       setProjectFromDb: assign({ project: (ctx, evt) => ({ ...evt.data }) }),
       updateLabeled: assign({
         project: (ctx, evt) => {
-          const { t, feature } = evt;
+          const { t, c } = evt;
           const labeled = ctx.project.labeled.map((arr, i) =>
-            i === feature ? arr.map((arr, j) => (j === t ? evt.labeled : arr)) : arr
+            i === c ? arr.map((arr, j) => (j === t ? evt.labeled : arr)) : arr
           );
           return { ...ctx.project, labeled };
         },


### PR DESCRIPTION
## What
Fixes canvas rendering bugs, namely #366 and #367, which were both caused by issues in the gpu rendering kernel. Specifically, a check is now called to ensure that a value is contained within the bounds of expected values before trying to render the label associated with that value (out of bounds indexing was resulting not in errors but the cells reappearing upon deletion). Additionally, the max number of cells displayed has been increased to 5000.

These changes were tested by Changhua and me and appear to be working properly.

## Why
Users can now render up to 5000 cells at once on a canvas and will not experience bugs when deleting the highest valued cells in a given frame. 