### PR TITLE
Change raw rescaling to happen on frontend + export original raw unscaled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,10 @@ fmd_config.cfg
 # production
 /build
 
+# models and other pickled files
+*.h5
+*.npy
+
 # misc
 .DS_Store
 .env.local

--- a/backend/deepcell_label/export.py
+++ b/backend/deepcell_label/export.py
@@ -51,7 +51,7 @@ class Export:
         """Loads the raw array from the raw.dat file."""
         with zipfile.ZipFile(self.labels_zip) as zf:
             with zf.open('raw.dat') as f:
-                raw = np.frombuffer(f.read(), np.uint8)
+                raw = np.frombuffer(f.read())
                 self.raw = np.reshape(
                     raw, (self.num_channels, self.duration, self.height, self.width)
                 )

--- a/backend/deepcell_label/loaders.py
+++ b/backend/deepcell_label/loaders.py
@@ -78,10 +78,6 @@ class Loader:
         """
         X = self.X
         if X is not None:
-            # Rescale data
-            max, min = np.max(X), np.min(X)
-            X = (X - min) / (max - min if max - min > 0 else 1) * 255
-            X = X.astype(np.uint8)
             # Move channel axis
             X = np.moveaxis(X, -1, 1)
             images = io.BytesIO()

--- a/frontend/src/Project/EditControls/CellControls/ToolButtons.js
+++ b/frontend/src/Project/EditControls/CellControls/ToolButtons.js
@@ -47,7 +47,7 @@ function ToolButtons() {
         </ToggleButton>
         <ToggleButton value={'replace'} sx={{ px: 0.5, py: 0 }}>
           <Tooltip title={<kbd>R</kbd>} placement='right'>
-            <div>Replace</div>
+            <div>Combine</div>
           </Tooltip>
         </ToggleButton>
         <ToggleButton value={'swap'} sx={{ px: 0.5, py: 0 }}>

--- a/frontend/src/Project/Instructions/CellsInstructions.js
+++ b/frontend/src/Project/Instructions/CellsInstructions.js
@@ -10,7 +10,7 @@ function ToolShortcuts() {
     <Shortcuts>
       <Shortcut text='Select' shortcut='V' />
       <Shortcut text='Delete' shortcut='Backspace' />
-      <Shortcut text='Replace' shortcut='R' />
+      <Shortcut text='Combine' shortcut='R' />
       <Shortcut text='Swap' shortcut='S' />
       <Shortcut text='New' shortcut='N' />
     </Shortcuts>
@@ -65,7 +65,7 @@ function CellsInstructions() {
               <br />
               <strong>Delete</strong> removes the cell.
               <br />
-              <strong>Replace</strong> combines a second cell with the selected cell. First selects
+              <strong>Combine</strong> combines a second cell with the selected cell. First selects
               a cell, and then selects the cell to replace.
               <br />
               <strong>Swap</strong> switches a second cell with the selected cell. First picks

--- a/frontend/src/Project/service/labels/arraysMachine.js
+++ b/frontend/src/Project/service/labels/arraysMachine.js
@@ -24,6 +24,7 @@ const createArraysMachine = (context) =>
       context: {
         raw: null,
         labeled: null,
+        rawOriginal: null,
         t: 0,
         feature: 0,
         channel: 0,
@@ -48,7 +49,7 @@ const createArraysMachine = (context) =>
               states: {
                 loading: {
                   on: {
-                    LOADED: { target: 'done', actions: ['setRaw', 'setLabeled'] },
+                    LOADED: { target: 'done', actions: ['setRaw', 'setLabeled', 'setRawOriginal'] },
                   },
                 },
                 done: { type: 'final' },
@@ -121,6 +122,7 @@ const createArraysMachine = (context) =>
       actions: {
         setRaw: assign({ raw: (ctx, evt) => evt.raw }),
         setLabeled: assign({ labeled: (ctx, evt) => evt.labeled }),
+        setRawOriginal: assign({ rawOriginal: (ctx, evt) => evt.rawOriginal }),
         setT: assign({ t: (ctx, evt) => evt.t }),
         setFeature: assign({ feature: (ctx, evt) => evt.feature }),
         setChannel: assign({ channel: (ctx, evt) => evt.channel }),
@@ -148,7 +150,7 @@ const createArraysMachine = (context) =>
         ),
         sendArrays: respond((ctx) => ({
           type: 'ARRAYS',
-          raw: ctx.raw,
+          raw: ctx.rawOriginal, // Send the original raw for export
           labeled: ctx.labeled,
         })),
         save: send('SAVE', { to: (ctx) => ctx.undoRef }),

--- a/frontend/src/Project/service/loadMachine.ts
+++ b/frontend/src/Project/service/loadMachine.ts
@@ -72,10 +72,11 @@ async function splitArrays(files: Files) {
   const labeledFile = files['y.ome.tiff'] as OmeTiff;
   const raw = await getRawRasters(rawFile.data[0]);
   const labeled = await getLabelRasters(labeledFile.data[0]);
-  return { raw, labeled };
+  const rawOriginal = await getRawOriginalRasters(rawFile.data[0]);
+  return { raw, labeled, rawOriginal };
 }
 
-async function getRawRasters(source: TiffPixelSource) {
+async function getRawOriginalRasters(source: TiffPixelSource) {
   const { labels, shape } = source;
   const c = shape[labels.indexOf('c')];
   const z = shape[labels.indexOf('z')];
@@ -85,12 +86,44 @@ async function getRawRasters(source: TiffPixelSource) {
     for (let j = 0; j < z; j++) {
       const selection = { t: 0, c: i, z: j };
       const raster = (await source.getRaster({ selection })) as Raster;
-      const frame = splitRows(raster) as Uint8Array[];
+      const frame = splitRows(raster);
       frames.push(frame);
     }
     channels.push(frames);
   }
   return channels;
+}
+
+async function getRawRasters(source: TiffPixelSource) {
+  const { labels, shape } = source;
+  const c = shape[labels.indexOf('c')];
+  const z = shape[labels.indexOf('z')];
+  const channels = [];
+  var max = 0;
+  var min = Infinity;
+  for (let i = 0; i < c; i++) {
+    const frames = [];
+    for (let j = 0; j < z; j++) {
+      const selection = { t: 0, c: i, z: j };
+      const raster = (await source.getRaster({ selection })) as Raster;
+      const frame = splitRows(raster);
+      // Record max and min across frames
+      for (let k = 0; k < frame.length; k++) {
+        for (let l = 0; l < frame[k].length; l++) {
+          if (frame[k][l] > max) {
+            max = frame[k][l];
+          }
+          if (frame[k][l] < min) {
+            min = frame[k][l]
+          }
+        }
+      }
+      frames.push(frame);
+    }
+    channels.push(frames);
+  }
+  const reshaped = reshapeRaw(channels, min, max) as Uint8Array[][][];
+  return reshaped;
 }
 
 async function getLabelRasters(source: TiffPixelSource) {
@@ -111,16 +144,48 @@ async function getLabelRasters(source: TiffPixelSource) {
   return channels;
 }
 
-type Raster = { data: Uint8Array | Int32Array; width: number; height: number };
+function reshapeRaw(channels: TypedArray[][][], min: number, max: number) {
+  // Normalize each pixel to 0-255 for rendering
+  for (let c = 0; c < channels.length; c++) {
+    for (let z = 0; z < channels[c].length; z++) {
+      for (let y = 0; y < channels[c][z].length; y++) {
+        for (let x = 0; x < channels[c][z][y].length; x++) {
+          channels[c][z][y][x] = Math.round((channels[c][z][y][x] - min) / (max - min) * 255);
+        }
+      }
+    }
+  }
+  return channels;
+}
+
+type TypedArray =
+  | Uint8Array
+  | Int8Array
+  | Uint16Array
+  | Int16Array
+  | Uint32Array
+  | Int32Array
+  | Float32Array
+  | Float64Array
+
+type Raster = { data: TypedArray; width: number; height: number };
 
 function splitRows(raster: Raster) {
   const { data, width, height } = raster;
   const frame = [];
   for (let i = 0; i < height; i++) {
     const row =
-      data instanceof Uint8Array
-        ? new Uint8Array(data.buffer, width * i, width)
-        : new Int32Array(data.buffer, width * i * 4, width);
+      data instanceof Uint8Array || data instanceof Int8Array ? (
+        new Uint8Array(data.buffer, width * i, width)
+      ) : data instanceof Uint16Array || data instanceof Int16Array ? (
+        new Uint16Array(data.buffer, width * i * 2, width)
+      ) : data instanceof Uint32Array ? (
+        new Uint32Array(data.buffer, width * i * 4, width)
+      ) : data instanceof Float32Array ? (
+        new Float32Array(data.buffer, width * i * 4, width)
+      ) : data instanceof Float64Array ? (
+        new Float64Array(data.buffer, width * i * 8, width)
+      ) : new Int32Array(data.buffer, width * i * 4, width);
     frame.push(row);
   }
   return frame;
@@ -137,6 +202,7 @@ interface Context {
   numFeatures: number | null;
   raw: Uint8Array[][][] | null;
   labeled: Int32Array[][][] | null;
+  rawOriginal: TypedArray[][][] | null;
   labels: Cells | null;
   spots: Spots | null;
   divisions: Divisions | null;
@@ -157,6 +223,7 @@ const createLoadMachine = (projectId: string) =>
         numFeatures: null,
         raw: null,
         labeled: null,
+        rawOriginal: null,
         labels: null,
         spots: null,
         divisions: null,
@@ -175,6 +242,7 @@ const createLoadMachine = (projectId: string) =>
             data: {
               raw: Uint8Array[][][];
               labeled: Int32Array[][][];
+              rawOriginal: TypedArray[][][];
             };
           };
         },
@@ -244,11 +312,13 @@ const createLoadMachine = (projectId: string) =>
         'set arrays': assign({
           raw: (_, event) => event.data.raw,
           labeled: (_, event) => event.data.labeled,
+          rawOriginal: (_, event) => event.data.rawOriginal,
         }),
         'send loaded': sendParent((ctx) => ({
           type: 'LOADED',
           raw: ctx.raw,
           labeled: ctx.labeled,
+          rawOriginal: ctx.rawOriginal,
           spots: ctx.spots,
           divisions: ctx.divisions,
           cells: ctx.cells,

--- a/frontend/src/Project/service/projectMachine.js
+++ b/frontend/src/Project/service/projectMachine.js
@@ -103,7 +103,7 @@ const createProjectMachine = (projectId) =>
         }),
         sendDimensions: send(
           (c, e) => {
-            const { raw, labeled } = e;
+            const { raw, labeled, rawOriginal } = e;
             return {
               type: 'DIMENSIONS',
               numChannels: raw.length,


### PR DESCRIPTION
## PR Addressing #373
* Non-png raw inputs are no longer rescaled at all on the backend in loaders.py (.png files are still rescaled to uint8)
* Instead, the frontend performs the rescaling on the raw array, and creates a second array "rawOriginal" which is passed to the arrayMachine. 
    * This is a "TypedArray" which can support Uint8, Int8, Uint16, Int16, Uint32, Int32, Float32, and Float64. This will require further testing (by @steveyu323?) for a variety of dtypes since I only had access to uint8 and float64 files
* On export, rawOriginal is zipped instead of the rescaled raw array, so download or submission will give the user the original raw unscaled tiff.
### Testing
* So far, I have tested uploading a file from Changhua that is float64, and the rendering on the site was fine. Upon downloading, the X.ome.tiff file inside retained float64 and the unscaled values. After reuploading this downloaded file to DCL, it looked fine as well. Functionality of all the editing and such still worked throughout all of this.
### Potential Issues / Enhancements
* The loading times do not seem to have suffered very significantly, but will look into using gpu.js to speed up the reshaping operation (which currently has 4 nested for loops).

### Small changes
* REPLACE tool was renamed to COMBINE on its button, tooltip, and instructions. The hotkey and code referencing the tool is unchanged.