### PR TITLE
Fix GPU rendering bugs, cell 0 bugs, and bug in saving raw array

### DIFF
--- a/backend/deepcell_label/export.py
+++ b/backend/deepcell_label/export.py
@@ -68,7 +68,6 @@ class Export:
         with zipfile.ZipFile(self.labels_zip) as zf:
             with zf.open('raw.dat') as f:
                 raw = np.frombuffer(f.read(), self.dtype)
-                print(raw.dtype)
                 self.raw = np.reshape(
                     raw, (self.num_channels, self.duration, self.height, self.width)
                 )

--- a/frontend/src/Project/Canvas/ToolCanvas/OuterOutlineCanvas.js
+++ b/frontend/src/Project/Canvas/ToolCanvas/OuterOutlineCanvas.js
@@ -55,8 +55,10 @@ function OuterOutlineCanvas({ setBitmaps, cell, color }) {
         }
         if (cells[value][cell] === 0 && value < numValues) {
           if (cells[north][cell] === 1 || cells[south][cell] === 1 || cells[west][cell] === 1 || cells[east][cell] === 1) {
-            const [r, g, b, a] = color;
-            this.color(r, g, b, a);
+            if (north < numValues && south < numValues && west < numValues && east < numValues) {
+              const [r, g, b, a] = color;
+              this.color(r, g, b, a);
+            }
           }
         }
       }`,

--- a/frontend/src/Project/Canvas/ToolCanvas/OuterOutlineCanvas.js
+++ b/frontend/src/Project/Canvas/ToolCanvas/OuterOutlineCanvas.js
@@ -33,7 +33,7 @@ function OuterOutlineCanvas({ setBitmaps, cell, color }) {
 
   useEffect(() => {
     const kernel = gpu.createKernel(
-      `function (data, cells, cell, color) {
+      `function (data, cells, numValues, cell, color) {
         const x = this.thread.x;
         const y = this.constants.h - 1 - this.thread.y;
         const value = data[y][x];
@@ -53,7 +53,7 @@ function OuterOutlineCanvas({ setBitmaps, cell, color }) {
         if (y !== this.constants.h - 1) {
           east = data[y + 1][x];
         }
-        if (cells[value][cell] === 0) {
+        if (cells[value][cell] === 0 && value < numValues) {
           if (cells[north][cell] === 1 || cells[south][cell] === 1 || cells[west][cell] === 1 || cells[east][cell] === 1) {
             const [r, g, b, a] = color;
             this.color(r, g, b, a);
@@ -80,7 +80,8 @@ function OuterOutlineCanvas({ setBitmaps, cell, color }) {
         return rest;
       });
     } else if (labeledArray && cellMatrix) {
-      kernel(labeledArray, cellMatrix, cell, color);
+      const numValues = cellMatrix.length;
+      kernel(labeledArray, cellMatrix, numValues, cell, color);
       // Rerender the parent canvas
       createImageBitmap(kernel.canvas).then((bitmap) => {
         setBitmaps((bitmaps) => ({ ...bitmaps, tool: bitmap }));

--- a/frontend/src/Project/Canvas/ToolCanvas/OutlineCellCanvas.js
+++ b/frontend/src/Project/Canvas/ToolCanvas/OutlineCellCanvas.js
@@ -54,7 +54,8 @@ function OutlineCellCanvas({ setBitmaps, cell, color }) {
           east = data[y + 1][x];
         }
         if (cells[value][cell] === 1 && value < numValues) {
-          if (cells[north][cell] === 0 || cells[south][cell] === 0 || cells[west][cell] === 0 || cells[east][cell] === 0) {
+          if (cells[north][cell] === 0 || cells[south][cell] === 0 || cells[west][cell] === 0 || cells[east][cell] === 0
+              || north >= numValues || south >= numValues || west >= numValues || east >= numValues) {
             const [r, g, b, a] = color;
             this.color(r, g, b, a);
           }

--- a/frontend/src/Project/Canvas/ToolCanvas/OutlineCellCanvas.js
+++ b/frontend/src/Project/Canvas/ToolCanvas/OutlineCellCanvas.js
@@ -33,7 +33,7 @@ function OutlineCellCanvas({ setBitmaps, cell, color }) {
 
   useEffect(() => {
     const kernel = gpu.createKernel(
-      `function (data, cells, cell, color) {
+      `function (data, cells, numValues, cell, color) {
         const x = this.thread.x;
         const y = this.constants.h - 1 - this.thread.y;
         const value = data[y][x];
@@ -53,7 +53,7 @@ function OutlineCellCanvas({ setBitmaps, cell, color }) {
         if (y !== this.constants.h - 1) {
           east = data[y + 1][x];
         }
-        if (cells[value][cell] === 1) {
+        if (cells[value][cell] === 1 && value < numValues) {
           if (cells[north][cell] === 0 || cells[south][cell] === 0 || cells[west][cell] === 0 || cells[east][cell] === 0) {
             const [r, g, b, a] = color;
             this.color(r, g, b, a);
@@ -80,7 +80,8 @@ function OutlineCellCanvas({ setBitmaps, cell, color }) {
         return rest;
       });
     } else if (labeledArray && cellMatrix) {
-      kernel(labeledArray, cellMatrix, cell, color);
+      const numValues = cellMatrix.length;
+      kernel(labeledArray, cellMatrix, numValues, cell, color);
       // Rerender the parent canvas
       createImageBitmap(kernel.canvas).then((bitmap) => {
         setBitmaps((bitmaps) => ({ ...bitmaps, tool: bitmap }));

--- a/frontend/src/Project/EditControls/SegmentControls/ActionButtons/AutofitButton.js
+++ b/frontend/src/Project/EditControls/SegmentControls/ActionButtons/AutofitButton.js
@@ -1,13 +1,21 @@
 import { useSelector } from '@xstate/react';
 import React, { useCallback } from 'react';
-import { useEditSegment } from '../../../ProjectContext';
+import { useEditSegment, useSelect } from '../../../ProjectContext';
 import ActionButton from './ActionButton';
 
 function AutofitButton(props) {
   const segment = useEditSegment();
   const grayscale = useSelector(segment, (state) => state.matches('display.grayscale'));
 
-  const onClick = useCallback(() => segment.send('AUTOFIT'), [segment]);
+  const select = useSelect();
+  const cell = useSelector(select, (state) => state.context.selected);
+
+  const onClick = useCallback(() => {
+    // Do not fit the background "cell 0"
+    if (cell !== 0) {
+      segment.send('AUTOFIT');
+    }
+  }, [segment, select, cell]);
 
   const tooltipText = (
     <span>

--- a/frontend/src/Project/EditControls/SegmentControls/ToolButtons/ThresholdButton.js
+++ b/frontend/src/Project/EditControls/SegmentControls/ToolButtons/ThresholdButton.js
@@ -1,6 +1,6 @@
 import { useSelector } from '@xstate/react';
 import React, { useCallback } from 'react';
-import { useEditSegment } from '../../../ProjectContext';
+import { useEditSegment, useSelect } from '../../../ProjectContext';
 import ToolButton from './ToolButton';
 
 function ThresholdButton(props) {
@@ -8,10 +8,15 @@ function ThresholdButton(props) {
   const tool = useSelector(segment, (state) => state.context.tool);
   const grayscale = useSelector(segment, (state) => state.matches('display.grayscale'));
 
-  const onClick = useCallback(
-    () => segment.send({ type: 'SET_TOOL', tool: 'threshold' }),
-    [segment]
-  );
+  const select = useSelect();
+  const cell = useSelector(select, (state) => state.context.selected);
+
+  const onClick = useCallback(() => {
+    segment.send({ type: 'SET_TOOL', tool: 'threshold' });
+    if (cell === 0) {
+      select.send('SELECT_NEW');
+    }
+  }, [segment, select, cell]);
 
   const tooltipText = grayscale ? (
     <span>

--- a/frontend/src/Project/service/edit/segment/editSegmentMachine.js
+++ b/frontend/src/Project/service/edit/segment/editSegmentMachine.js
@@ -90,7 +90,7 @@ const createEditSegmentMachine = (context) =>
         },
       },
       on: {
-        EXIT: { actions: 'forwardToTool' },
+        EXIT: { actions: ['forwardToTool', send({ type: 'SET_TOOL', tool: 'select' })] },
         // from canvas event bus (forwarded from parent)
         mousedown: { actions: 'forwardToTool' },
         mouseup: { actions: 'forwardToTool' },

--- a/frontend/src/Project/service/loadMachine.ts
+++ b/frontend/src/Project/service/loadMachine.ts
@@ -122,7 +122,7 @@ async function getRawRasters(source: TiffPixelSource) {
     }
     channels.push(frames);
   }
-  const reshaped = reshapeRaw(channels, min, max) as Uint8Array[][][];
+  const reshaped = reshapeRaw(channels, min, max);
   return reshaped;
 }
 
@@ -145,17 +145,28 @@ async function getLabelRasters(source: TiffPixelSource) {
 }
 
 function reshapeRaw(channels: TypedArray[][][], min: number, max: number) {
+  const size_c = channels.length;
+  const size_z = channels[0].length;
+  const size_y = channels[0][0].length;
+  const size_x = channels[0][0][0].length;
+  const reshaped = [];
   // Normalize each pixel to 0-255 for rendering
-  for (let c = 0; c < channels.length; c++) {
-    for (let z = 0; z < channels[c].length; z++) {
-      for (let y = 0; y < channels[c][z].length; y++) {
-        for (let x = 0; x < channels[c][z][y].length; x++) {
-          channels[c][z][y][x] = Math.round(((channels[c][z][y][x] - min) / (max - min)) * 255);
+  for (let c = 0; c < size_c; c++) {
+    const frames = [];
+    for (let z = 0; z < size_z; z++) {
+      const frame = [];
+      for (let y = 0; y < size_y; y++) {
+        const row = new Uint8Array(size_x);
+        for (let x = 0; x < size_x; x++) {
+          row[x] = Math.round(((channels[c][z][y][x] - min) / (max - min)) * 255);
         }
+        frame.push(row);
       }
+      frames.push(frame);
     }
+    reshaped.push(frames);
   }
-  return channels;
+  return reshaped;
 }
 
 type TypedArray =


### PR DESCRIPTION
## PR Addressing #380, #382, and more
* Fixed GPU rendering bugs for the COMBINE and FLOOD tools (#380).
    * These tools also rendered outlines when used and ran into the same issues as those fixed in #376, so similar fixes were applied.
* Fixed bugs related to "Cell 0" edits (#382).
    * If no cell was selected, it was possible to create cells with label 0 on the canvas. Possible from:
        1. Hitting `esc` while using the BRUSH tool. Fixed by switching to SELECT when `esc` is hit.
        2. Hitting `esc` to select nothing and then switching to the THRESHOLD tool. Fixed by selecting a new cell when hitting the THRESHOLD tool if current cell is 0.
        3. Hitting `esc` to select nothing and then pressing the autofit tool. Fixed by not using the autofit tool if current cell is 0.
* Fixed bug in how raw array was saved in the reshaping.
    * Threshold and watershed tools were broken because these tools pass the raw array to the backend. Originally the unscaled raw array was simply being scaled and the scaling function was called with "as Uint8Array[][][]" but this doesn't work due to how the array buffers work, so a new array is made when the reshaping is done to fix this.
