### PR TITLE
Update URL to flake8 to fix precommit job.

### DIFF
--- a/.github/workflows/precommithooks.yaml
+++ b/.github/workflows/precommithooks.yaml
@@ -7,8 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     hooks:
       - id: isort
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
       - id: flake8


### PR DESCRIPTION
In principle this could use a bigger makeover; specifically reviewing the versions of all the hooks. In practice most of them should be replaced with ruff.

General maintenance to try to get the CI back into a fully operational state.