### PR TITLE
Implement centroid calculations and channel expression unit testing

### DIFF
--- a/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionPlot.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionPlot.js
@@ -1,102 +1,120 @@
-import SsidChartIcon from '@mui/icons-material/SsidChart';
 import PsychologyIcon from '@mui/icons-material/Psychology';
+import SsidChartIcon from '@mui/icons-material/SsidChart';
 import { Box } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import { useSelector } from '@xstate/react';
 import { useState } from 'react';
+import { useCanvas, useChannelExpression, useLabelMode } from '../../ProjectContext';
 import AddRemoveCancel from './ChannelExpressionUI/AddRemoveCancel';
 import Calculate from './ChannelExpressionUI/Calculate';
 import ChannelPlot from './ChannelExpressionUI/ChannelPlot';
 import ChannelSelect from './ChannelExpressionUI/ChannelSelect';
-import LearnTab from './TrainingUI/LearnTab';
-import { useCanvas, useChannelExpression, useLabelMode } from '../../ProjectContext';
 import EmbeddingPlot from './TrainingUI/EmbeddingPlot';
+import LearnTab from './TrainingUI/LearnTab';
 
 function TabPanel({ children, value, index }) {
-    return value === index && children;
-  }
+  return value === index && children;
+}
 
 function ChannelExpressionPlot() {
+  const channelExpression = useChannelExpression();
+  const labelMode = useLabelMode();
+  const canvas = useCanvas();
+  const cellTypesEditing = useSelector(labelMode, (state) => state.matches('editCellTypes'));
+  const calculations = useSelector(channelExpression, (state) => state.context.calculations);
+  const embedding = useSelector(channelExpression, (state) => state.context.reduction);
+  const sw = useSelector(canvas, (state) => state.context.width);
+  const sh = useSelector(canvas, (state) => state.context.height);
+  const scale = useSelector(canvas, (state) => state.context.scale);
+  const [channelX, setChannelX] = useState(0);
+  const [channelY, setChannelY] = useState(1);
+  const [tab, setTab] = useState(0);
+  const [plot, setPlot] = useState('scatter');
 
-    const channelExpression = useChannelExpression();
-    const labelMode = useLabelMode();
-    const canvas = useCanvas();
-    const cellTypesEditing = useSelector(labelMode, (state) => state.matches('editCellTypes'));
-    const calculations = useSelector(channelExpression, (state) => state.context.calculations);
-    const embedding = useSelector(channelExpression, (state) => state.context.reduction);
-    const logs = useSelector(channelExpression, (state) => state.context.logs);
-    const sw = useSelector(canvas, (state) => state.context.width);
-    const sh = useSelector(canvas, (state) => state.context.height);
-    const scale = useSelector(canvas, (state) => state.context.scale);
-    const [channelX, setChannelX] = useState(0);
-    const [channelY, setChannelY] = useState(1);
-    const [tab, setTab] = useState(0);
-    const [plot, setPlot] = useState('scatter');
+  const panelStyle = {
+    position: 'absolute',
+    top: 255,
+    left: 500 + sw * scale,
+    height: scale * sh - 60,
+    overflow: 'hidden',
+    overflowY: 'auto',
+    '&::-webkit-scrollbar': {
+      width: 5,
+      borderRadius: 10,
+      backgroundColor: 'rgba(0,0,0,0.1)',
+    },
+    '&::-webkit-scrollbar-thumb': {
+      borderRadius: 10,
+      backgroundColor: 'rgba(100,100,100,0.5)',
+    },
+  };
 
-    const panelStyle = {
-        position: 'absolute', 
-        top: 255    ,
-        left: 500 + sw * scale, 
-        height: scale * sh - 60,
-        overflow: 'hidden', 
-        overflowY: 'auto',
-        '&::-webkit-scrollbar': {
-            width: 5,
-            borderRadius: 10,
-            backgroundColor: 'rgba(0,0,0,0.1)'
-        },
-        '&::-webkit-scrollbar-thumb': {
-            borderRadius: 10,
-            backgroundColor: 'rgba(100,100,100,0.5)',
-        }
-    }
+  const handleTab = (_, newValue) => {
+    setTab(newValue);
+  };
 
-    const handleTab = (_, newValue) => {
-        setTab(newValue);
-    };
-
-    return (
-        cellTypesEditing
-        ? <Box>
-            <Tabs
-                sx={{position: 'absolute', left: 500 + sw * scale, height: 10 }}
-                value={tab}
-                onChange={handleTab}
-                variant='fullWidth'
-            >
-                <Tab sx={{width: 175, top: -12}} value={0} label='Plot' icon={<SsidChartIcon/>} iconPosition='start' />
-                <Tab sx={{width: 175, top: -12}} value={1} label='Learn' icon={<PsychologyIcon/>} iconPosition='start' />
-            </Tabs>
-            <Box sx={panelStyle}> 
-                <Grid container direction='column' spacing={2}>
-                    <TabPanel value={tab} index={0}>
-                        <Calculate />
-                        {calculations
-                            ? <>
-                                <ChannelSelect channelX={channelX} setChannelX={setChannelX} channelY={channelY} setChannelY={setChannelY} setPlot={setPlot} plot={plot} />
-                                <ChannelPlot channelX={channelX} channelY={channelY} calculations={calculations} plot={plot} />
-                                <AddRemoveCancel />
-                            </>
-                            : null
-                        }
-                    </TabPanel>
-                    <TabPanel value={tab} index={1}>
-                        <LearnTab />
-                        {embedding
-                            ? <>
-                                <EmbeddingPlot embedding={embedding} />
-                                <AddRemoveCancel />
-                            </>
-                            : null
-                        }
-                    </TabPanel>
-                </Grid>
-            </Box>
-        </Box>
-        : null
-  );
+  return cellTypesEditing ? (
+    <Box>
+      <Tabs
+        sx={{ position: 'absolute', left: 500 + sw * scale, height: 10 }}
+        value={tab}
+        onChange={handleTab}
+        variant='fullWidth'
+      >
+        <Tab
+          sx={{ width: 175, top: -12 }}
+          value={0}
+          label='Plot'
+          icon={<SsidChartIcon />}
+          iconPosition='start'
+        />
+        <Tab
+          sx={{ width: 175, top: -12 }}
+          value={1}
+          label='Learn'
+          icon={<PsychologyIcon />}
+          iconPosition='start'
+        />
+      </Tabs>
+      <Box sx={panelStyle}>
+        <Grid container direction='column' spacing={2}>
+          <TabPanel value={tab} index={0}>
+            <Calculate />
+            {calculations ? (
+              <>
+                <ChannelSelect
+                  channelX={channelX}
+                  setChannelX={setChannelX}
+                  channelY={channelY}
+                  setChannelY={setChannelY}
+                  setPlot={setPlot}
+                  plot={plot}
+                />
+                <ChannelPlot
+                  channelX={channelX}
+                  channelY={channelY}
+                  calculations={calculations}
+                  plot={plot}
+                />
+                <AddRemoveCancel />
+              </>
+            ) : null}
+          </TabPanel>
+          <TabPanel value={tab} index={1}>
+            <LearnTab />
+            {embedding ? (
+              <>
+                <EmbeddingPlot embedding={embedding} />
+                <AddRemoveCancel />
+              </>
+            ) : null}
+          </TabPanel>
+        </Grid>
+      </Box>
+    </Box>
+  ) : null;
 }
 
 export default ChannelExpressionPlot;

--- a/frontend/src/Project/EditControls/CellTypeControls/TrainingUI/LearnTab.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/TrainingUI/LearnTab.js
@@ -1,46 +1,50 @@
 import { Button, MenuItem, TextField } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import { useState } from 'react';
-import TrainingButtons from './TrainingButtons';
 import { useChannelExpression } from '../../../ProjectContext';
+import TrainingButtons from './TrainingButtons';
 
 function LearnTab() {
-    
-    const quantities = ['Mean', 'Total'];
-    const [embedding, setEmbedding] = useState(0);
-    const channelExpression = useChannelExpression();
+  const quantities = ['Position', 'Mean', 'Total'];
+  const [embedding, setEmbedding] = useState(0);
+  const channelExpression = useChannelExpression();
 
-    const handleVisualize = () => {
-        channelExpression.send({ type: 'CALCULATE_UMAP', stat: quantities[embedding] });
-    };
+  const handleVisualize = () => {
+    if (quantities[embedding] === 'Position') {
+      channelExpression.send({ type: 'CALCULATE', stat: quantities[embedding] });
+    } else {
+      channelExpression.send({ type: 'CALCULATE_UMAP', stat: quantities[embedding] });
+    }
+  };
 
-    return (
-        <>
-        <Grid item display='flex' alignItems='center' sx={{marginLeft: 1.4, marginTop: 1}}>
-            <TextField
-                select
-                size='small'
-                value={embedding}
-                label='Embedding'
-                onChange={(evt) => setEmbedding(evt.target.value)}
-                sx={{width: 154.6}}>
-                {quantities.map((opt, index) => (
-                <MenuItem key={index} value={index}>
-                    {opt}
-                </MenuItem>
-                ))}
-            </TextField>
-            <Button
-                sx={{ marginLeft: 2, width: 154.6, height: 35 }}
-                variant='contained'
-                onClick={handleVisualize}
-            >
-                Visualize
-            </Button>
-        </Grid>
-        <TrainingButtons />
-        </>
-    );
-};
+  return (
+    <>
+      <Grid item display='flex' alignItems='center' sx={{ marginLeft: 1.4, marginTop: 1 }}>
+        <TextField
+          select
+          size='small'
+          value={embedding}
+          label='Embedding'
+          onChange={(evt) => setEmbedding(evt.target.value)}
+          sx={{ width: 154.6 }}
+        >
+          {quantities.map((opt, index) => (
+            <MenuItem key={index} value={index}>
+              {opt}
+            </MenuItem>
+          ))}
+        </TextField>
+        <Button
+          sx={{ marginLeft: 2, width: 154.6, height: 35 }}
+          variant='contained'
+          onClick={handleVisualize}
+        >
+          Visualize
+        </Button>
+      </Grid>
+      <TrainingButtons />
+    </>
+  );
+}
 
 export default LearnTab;

--- a/frontend/src/Project/service/labels/channelExpression.test.ts
+++ b/frontend/src/Project/service/labels/channelExpression.test.ts
@@ -1,0 +1,217 @@
+import { calculateMean, calculatePosition, calculateTotal } from './channelExpressionMachine';
+
+test('no cells leads to empty lists', () => {
+  const ctx = {
+    t: 0,
+    feature: 0,
+    labeled: [
+      [0, 0],
+      [0, 0],
+    ],
+    raw: [
+      [
+        [0, 1],
+        [2, 3],
+      ],
+      [
+        [0, 1],
+        [2, 3],
+      ],
+    ],
+    cells: [],
+    numCells: 0,
+  };
+  expect(calculateMean(ctx)).toEqual([[], []]);
+  expect(calculatePosition(ctx)).toEqual([[], []]);
+  expect(calculateTotal(ctx)).toEqual([[], []]);
+});
+
+test('non-existent cell leads to NaNs', () => {
+  const ctx = {
+    t: 0,
+    feature: 0,
+    labeled: [
+      [0, 0],
+      [0, 0],
+    ],
+    raw: [
+      [
+        [0, 1],
+        [2, 3],
+      ],
+      [
+        [0, 1],
+        [2, 3],
+      ],
+    ],
+    cells: [{ cell: 0, value: 1, t: 0, c: 0 }],
+    numCells: 1,
+  };
+  expect(calculateMean(ctx)).toEqual([[NaN], [NaN]]);
+  expect(calculateTotal(ctx)).toEqual([[NaN], [NaN]]);
+  expect(calculatePosition(ctx)).toEqual([[NaN], [NaN]]);
+});
+
+test('one cell calculates mean', () => {
+  const ctx = {
+    t: 0,
+    feature: 0,
+    labeled: [
+      [1, 1],
+      [1, 1],
+    ],
+    raw: [
+      [
+        [
+          [3, 2],
+          [3, 4],
+        ],
+      ],
+      [
+        [
+          [100, 100],
+          [100, 100],
+        ],
+      ],
+    ],
+    cells: [{ cell: 0, value: 1, t: 0, c: 0 }],
+    numCells: 1,
+  };
+  expect(calculateMean(ctx)).toEqual([[3], [100]]);
+});
+
+test('one cell calculates total', () => {
+  const ctx = {
+    t: 0,
+    feature: 0,
+    labeled: [
+      [1, 1],
+      [1, 1],
+    ],
+    raw: [
+      [
+        [
+          [3, 2],
+          [3, 4],
+        ],
+      ],
+      [
+        [
+          [100, 100],
+          [100, 100],
+        ],
+      ],
+    ],
+    cells: [{ cell: 0, value: 1, t: 0, c: 0 }],
+    numCells: 1,
+  };
+  expect(calculateTotal(ctx)).toEqual([[12], [400]]);
+});
+
+test('one cell calculates position', () => {
+  const ctx = {
+    t: 0,
+    feature: 0,
+    labeled: [
+      [1, 1],
+      [1, 1],
+    ],
+    cells: [{ cell: 0, value: 1, t: 0, c: 0 }],
+    numCells: 1,
+  };
+  expect(calculatePosition(ctx)).toEqual([[0.5], [0.5]]);
+});
+
+test('two overlapping cells calculate mean', () => {
+  const ctx = {
+    t: 0,
+    feature: 0,
+    labeled: [
+      [1, 3],
+      [1, 2],
+    ],
+    raw: [
+      [
+        [
+          [3, 3],
+          [3, 5],
+        ],
+      ],
+      [
+        [
+          [100, 100],
+          [100, 50],
+        ],
+      ],
+    ],
+    cells: [
+      { cell: 0, value: 1, t: 0, c: 0 },
+      { cell: 1, value: 2, t: 0, c: 0 },
+      { cell: 0, value: 3, t: 0, c: 0 },
+      { cell: 1, value: 3, t: 0, c: 0 },
+    ],
+    numCells: 2,
+  };
+  expect(calculateMean(ctx)).toEqual([
+    [3, 4],
+    [100, 75],
+  ]);
+});
+
+test('two overlapping cells calculate total', () => {
+  const ctx = {
+    t: 0,
+    feature: 0,
+    labeled: [
+      [1, 3],
+      [1, 2],
+    ],
+    raw: [
+      [
+        [
+          [3, 3],
+          [3, 5],
+        ],
+      ],
+      [
+        [
+          [100, 100],
+          [100, 50],
+        ],
+      ],
+    ],
+    cells: [
+      { cell: 0, value: 1, t: 0, c: 0 },
+      { cell: 1, value: 2, t: 0, c: 0 },
+      { cell: 0, value: 3, t: 0, c: 0 },
+      { cell: 1, value: 3, t: 0, c: 0 },
+    ],
+    numCells: 2,
+  };
+  expect(calculateTotal(ctx)).toEqual([
+    [9, 8],
+    [300, 150],
+  ]);
+});
+
+test('two overlapping cells calculate position', () => {
+  const ctx = {
+    t: 0,
+    feature: 0,
+    labeled: [
+      [1, 3],
+      [1, 2],
+    ],
+    cells: [
+      { cell: 0, value: 1, t: 0, c: 0 },
+      { cell: 1, value: 2, t: 0, c: 0 },
+      { cell: 0, value: 3, t: 0, c: 0 },
+      { cell: 1, value: 3, t: 0, c: 0 },
+    ],
+    numCells: 2,
+  };
+  expect(calculatePosition(ctx)).toEqual([
+    [1 / 3, 1],
+    [2 / 3, 0.5],
+  ]);
+});


### PR DESCRIPTION
## What
* Adds ability to calculate centroids of each cell in order to spatially visualize them on the plotly chart and graph them
* Adds unit testing for both the new centroid calculations and for the original mean and total calculations in channelExpressionMachine.js