### PR TITLE
Restrict subset of CI jobs to main repo.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,6 +11,9 @@ on:
 
 jobs:
   e2e-tests:
+    # e2e tests require keys which are only available (via secrets) in the
+    # main repo. Therefore don't try to run this job on forks
+    if: github.repository == 'vanvalenlab/deepcell-label'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## What
* Attempt to support CI jobs from forks

## Why
* To prevent spurious CI failures for PRs originating from forks
