### PR TITLE
Prepend env vars with CYPRESS_

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,8 +44,8 @@ jobs:
       - name: Cypress run
         uses: cypress-io/github-action@v5
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          CYPRESS_AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          CYPRESS_AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         with:
           working-directory: frontend
           start: |


### PR DESCRIPTION
According to the cypress-io action docs, env vars prepended this way are automatically forwarded to the cypress environment.

Follow-up to #406 in response to @ykevu 's observation that the test was not being run on `main` post-merge either.

What we expect:
 - Test to be skipped on PR opening/push (i.e. `label.` tests will only have 5 tests)
 - Test to run post-merge (i.e. `label.` tests will have 6 tests, all green)