### PR TITLE
Allow calculations and training across all frames

### DIFF
--- a/frontend/cypress/e2e/celltypes.cy.js
+++ b/frontend/cypress/e2e/celltypes.cy.js
@@ -9,6 +9,7 @@ after(() => {
 
 describe('Cell Type Editing', () => {
   beforeEach(() => {
+    cy.viewport(1280, 720);
     const id = getUniqueId();
     cy.intercept('GET', `/api/project/${id}`, { fixture: 'rgb.zip' });
     cy.visit(`/project?projectId=${id}`);

--- a/frontend/src/Footer/Footer.js
+++ b/frontend/src/Footer/Footer.js
@@ -23,7 +23,10 @@ export default function Footer() {
       </Typography>
       <Typography variant='caption' align='center' color='textSecondary' component='p'>
         For any questions or issues, please post on our{' '}
-        <Link href='https://github.com/vanvalenlab/deepcell-label/issues'>GitHub Issues</Link> page.
+        <Link href='https://github.com/vanvalenlab/deepcell-label/issues'>GitHub Issues</Link> page.{' '}
+        {/* <Link href='https://github.com/vanvalenlab/deepcell-label/commit/256862c378b3538b4b523d2bdcc5627d9f2ee4ed'>
+          (Current deployment)
+        </Link>{' '} */}
       </Typography>
     </MuiFooter>
   );

--- a/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionPlot.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionPlot.js
@@ -1,102 +1,120 @@
-import SsidChartIcon from '@mui/icons-material/SsidChart';
 import PsychologyIcon from '@mui/icons-material/Psychology';
+import SsidChartIcon from '@mui/icons-material/SsidChart';
 import { Box } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import { useSelector } from '@xstate/react';
 import { useState } from 'react';
+import { useCanvas, useChannelExpression, useLabelMode } from '../../ProjectContext';
 import AddRemoveCancel from './ChannelExpressionUI/AddRemoveCancel';
 import Calculate from './ChannelExpressionUI/Calculate';
 import ChannelPlot from './ChannelExpressionUI/ChannelPlot';
 import ChannelSelect from './ChannelExpressionUI/ChannelSelect';
-import LearnTab from './TrainingUI/LearnTab';
-import { useCanvas, useChannelExpression, useLabelMode } from '../../ProjectContext';
 import EmbeddingPlot from './TrainingUI/EmbeddingPlot';
+import LearnTab from './TrainingUI/LearnTab';
 
 function TabPanel({ children, value, index }) {
-    return value === index && children;
-  }
+  return value === index && children;
+}
 
 function ChannelExpressionPlot() {
+  const channelExpression = useChannelExpression();
+  const labelMode = useLabelMode();
+  const canvas = useCanvas();
+  const cellTypesEditing = useSelector(labelMode, (state) => state.matches('editCellTypes'));
+  const calculations = useSelector(channelExpression, (state) => state.context.calculations);
+  const embedding = useSelector(channelExpression, (state) => state.context.reduction);
+  const sw = useSelector(canvas, (state) => state.context.width);
+  const sh = useSelector(canvas, (state) => state.context.height);
+  const scale = useSelector(canvas, (state) => state.context.scale);
+  const [channelX, setChannelX] = useState(0);
+  const [channelY, setChannelY] = useState(1);
+  const [tab, setTab] = useState(0);
+  const [plot, setPlot] = useState('scatter');
 
-    const channelExpression = useChannelExpression();
-    const labelMode = useLabelMode();
-    const canvas = useCanvas();
-    const cellTypesEditing = useSelector(labelMode, (state) => state.matches('editCellTypes'));
-    const calculations = useSelector(channelExpression, (state) => state.context.calculations);
-    const embedding = useSelector(channelExpression, (state) => state.context.reduction);
-    const logs = useSelector(channelExpression, (state) => state.context.logs);
-    const sw = useSelector(canvas, (state) => state.context.width);
-    const sh = useSelector(canvas, (state) => state.context.height);
-    const scale = useSelector(canvas, (state) => state.context.scale);
-    const [channelX, setChannelX] = useState(0);
-    const [channelY, setChannelY] = useState(1);
-    const [tab, setTab] = useState(0);
-    const [plot, setPlot] = useState('scatter');
+  const panelStyle = {
+    position: 'absolute',
+    top: 255,
+    left: 500 + sw * scale,
+    height: scale * sh - 60,
+    overflow: 'hidden',
+    overflowY: 'auto',
+    '&::-webkit-scrollbar': {
+      width: 5,
+      borderRadius: 10,
+      backgroundColor: 'rgba(0,0,0,0.1)',
+    },
+    '&::-webkit-scrollbar-thumb': {
+      borderRadius: 10,
+      backgroundColor: 'rgba(100,100,100,0.5)',
+    },
+  };
 
-    const panelStyle = {
-        position: 'absolute', 
-        top: 255    ,
-        left: 500 + sw * scale, 
-        height: scale * sh - 60,
-        overflow: 'hidden', 
-        overflowY: 'auto',
-        '&::-webkit-scrollbar': {
-            width: 5,
-            borderRadius: 10,
-            backgroundColor: 'rgba(0,0,0,0.1)'
-        },
-        '&::-webkit-scrollbar-thumb': {
-            borderRadius: 10,
-            backgroundColor: 'rgba(100,100,100,0.5)',
-        }
-    }
+  const handleTab = (_, newValue) => {
+    setTab(newValue);
+  };
 
-    const handleTab = (_, newValue) => {
-        setTab(newValue);
-    };
-
-    return (
-        cellTypesEditing
-        ? <Box>
-            <Tabs
-                sx={{position: 'absolute', left: 500 + sw * scale, height: 10 }}
-                value={tab}
-                onChange={handleTab}
-                variant='fullWidth'
-            >
-                <Tab sx={{width: 175, top: -12}} value={0} label='Plot' icon={<SsidChartIcon/>} iconPosition='start' />
-                <Tab sx={{width: 175, top: -12}} value={1} label='Learn' icon={<PsychologyIcon/>} iconPosition='start' />
-            </Tabs>
-            <Box sx={panelStyle}> 
-                <Grid container direction='column' spacing={2}>
-                    <TabPanel value={tab} index={0}>
-                        <Calculate />
-                        {calculations
-                            ? <>
-                                <ChannelSelect channelX={channelX} setChannelX={setChannelX} channelY={channelY} setChannelY={setChannelY} setPlot={setPlot} plot={plot} />
-                                <ChannelPlot channelX={channelX} channelY={channelY} calculations={calculations} plot={plot} />
-                                <AddRemoveCancel />
-                            </>
-                            : null
-                        }
-                    </TabPanel>
-                    <TabPanel value={tab} index={1}>
-                        <LearnTab />
-                        {embedding
-                            ? <>
-                                <EmbeddingPlot embedding={embedding} />
-                                <AddRemoveCancel />
-                            </>
-                            : null
-                        }
-                    </TabPanel>
-                </Grid>
-            </Box>
-        </Box>
-        : null
-  );
+  return cellTypesEditing ? (
+    <Box>
+      <Tabs
+        sx={{ position: 'absolute', left: 500 + sw * scale, height: 10 }}
+        value={tab}
+        onChange={handleTab}
+        variant='fullWidth'
+      >
+        <Tab
+          sx={{ width: 175, top: -12 }}
+          value={0}
+          label='Plot'
+          icon={<SsidChartIcon />}
+          iconPosition='start'
+        />
+        <Tab
+          sx={{ width: 175, top: -12 }}
+          value={1}
+          label='Learn'
+          icon={<PsychologyIcon />}
+          iconPosition='start'
+        />
+      </Tabs>
+      <Box sx={panelStyle}>
+        <Grid container direction='column' spacing={2}>
+          <TabPanel value={tab} index={0}>
+            <Calculate />
+            {calculations ? (
+              <>
+                <ChannelSelect
+                  channelX={channelX}
+                  setChannelX={setChannelX}
+                  channelY={channelY}
+                  setChannelY={setChannelY}
+                  setPlot={setPlot}
+                  plot={plot}
+                />
+                <ChannelPlot
+                  channelX={channelX}
+                  channelY={channelY}
+                  calculations={calculations}
+                  plot={plot}
+                />
+                <AddRemoveCancel />
+              </>
+            ) : null}
+          </TabPanel>
+          <TabPanel value={tab} index={1}>
+            <LearnTab />
+            {embedding ? (
+              <>
+                <EmbeddingPlot embedding={embedding} />
+                <AddRemoveCancel />
+              </>
+            ) : null}
+          </TabPanel>
+        </Grid>
+      </Box>
+    </Box>
+  ) : null;
 }
 
 export default ChannelExpressionPlot;

--- a/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionPlot.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionPlot.js
@@ -31,12 +31,12 @@ function ChannelExpressionPlot() {
   const [channelX, setChannelX] = useState(0);
   const [channelY, setChannelY] = useState(1);
   const [tab, setTab] = useState(0);
-  const [plot, setPlot] = useState('scatter');
+  const [plot, setPlot] = useState('histogram');
 
   const panelStyle = {
-    position: 'absolute',
-    top: 255,
-    left: 500 + sw * scale,
+    position: 'relative',
+    right: window.innerWidth - 860 - sw * scale,
+    paddingTop: 2,
     height: scale * sh - 60,
     overflow: 'hidden',
     overflowY: 'auto',
@@ -58,7 +58,7 @@ function ChannelExpressionPlot() {
   return cellTypesEditing ? (
     <Box>
       <Tabs
-        sx={{ position: 'absolute', left: 500 + sw * scale, height: 10 }}
+        sx={{ position: 'relative', right: window.innerWidth - 860 - sw * scale, height: 10 }}
         value={tab}
         onChange={handleTab}
         variant='fullWidth'

--- a/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/AddRemoveCancel.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/AddRemoveCancel.js
@@ -46,7 +46,7 @@ function AddRemoveCancel() {
           size='small'
           value={cellType}
           onChange={handleCellType}
-          sx={{ width: 325.5, marginLeft: 1.45 }}
+          sx={{ width: '97%' }}
         >
           {cellTypeIds.map((opt, index) => (
             <MenuItem key={index} value={index}>
@@ -55,9 +55,9 @@ function AddRemoveCancel() {
           ))}
         </TextField>
       </Grid>
-      <Grid item sx={{ marginLeft: 0.5, marginBottom: 1 }}>
+      <Grid item sx={{ marginBottom: 1 }}>
         <Button
-          sx={{ marginLeft: 1, width: 95 }}
+          sx={{ width: '31%' }}
           disabled={!selecting}
           variant='contained'
           onClick={addCellTypes}
@@ -66,8 +66,8 @@ function AddRemoveCancel() {
         </Button>
         <Button
           sx={{
-            marginLeft: 1,
-            width: 107,
+            marginLeft: '2%',
+            width: '31%',
             backgroundColor: 'rgba(244,67,54,1)',
             '&:hover': { backgroundColor: 'rgba(224,47,34,1)' },
           }}
@@ -79,8 +79,8 @@ function AddRemoveCancel() {
         </Button>
         <Button
           sx={{
-            marginLeft: 1,
-            width: 105,
+            marginLeft: '2%',
+            width: '31%',
             backgroundColor: 'rgba(0,0,0,0.1)',
             color: 'rgba(0,0,0,0.65)',
             '&:hover': { backgroundColor: 'rgba(0,0,0,0.2)' },

--- a/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/Calculate.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/Calculate.js
@@ -9,7 +9,7 @@ function Calculate() {
   const [stat, setStat] = useState(0);
 
   const handleCalculation = () => {
-    channelExpression.send({ type: 'CALCULATE', stat: quantities[stat] });
+    channelExpression.send({ type: 'CALCULATE', stat: quantities[stat], whole: true });
   };
 
   return (

--- a/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/Calculate.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/Calculate.js
@@ -1,7 +1,8 @@
-import { Button, MenuItem, TextField } from '@mui/material';
+import { Box, Button, MenuItem, TextField } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import { useState } from 'react';
 import { useChannelExpression } from '../../../ProjectContext';
+import CalculateWholeToggle from './CalculateWholeToggle';
 
 function Calculate() {
   const channelExpression = useChannelExpression();
@@ -13,25 +14,32 @@ function Calculate() {
   };
 
   return (
-    <Grid item display='flex' sx={{ marginTop: 1 }}>
-      <TextField
-        select
-        size='small'
-        value={stat}
-        label='Statistic'
-        onChange={(evt) => setStat(evt.target.value)}
-        sx={{ width: 130 }}
-      >
-        {quantities.map((opt, index) => (
-          <MenuItem key={index} value={index}>
-            {opt}
-          </MenuItem>
-        ))}
-      </TextField>
-      <Button sx={{ marginLeft: 2 }} variant='contained' onClick={handleCalculation}>
-        Calculate
-      </Button>
-    </Grid>
+    <>
+      <Grid item display='flex'>
+        <TextField
+          select
+          size='small'
+          value={stat}
+          label='Statistic'
+          onChange={(evt) => setStat(evt.target.value)}
+          sx={{ width: '47%' }}
+        >
+          {quantities.map((opt, index) => (
+            <MenuItem key={index} value={index}>
+              {opt}
+            </MenuItem>
+          ))}
+        </TextField>
+        <Box sx={{ marginLeft: '1%' }}>
+          <CalculateWholeToggle />
+        </Box>
+      </Grid>
+      <Grid item>
+        <Button sx={{ width: '97%' }} variant='contained' onClick={handleCalculation}>
+          Calculate
+        </Button>
+      </Grid>
+    </>
   );
 }
 

--- a/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/CalculateWholeToggle.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/CalculateWholeToggle.js
@@ -4,7 +4,7 @@ import { styled } from '@mui/material/styles';
 import Switch from '@mui/material/Switch';
 import Tooltip, { tooltipClasses } from '@mui/material/Tooltip';
 import { useSelector } from '@xstate/react';
-import { useChannelExpression } from '../../../ProjectContext';
+import { useChannelExpression, useTraining } from '../../../ProjectContext';
 
 const CustomWidthTooltip = styled(({ className, ...props }) => (
   <Tooltip {...props} classes={{ popper: className }} />
@@ -16,10 +16,12 @@ const CustomWidthTooltip = styled(({ className, ...props }) => (
 
 function CalculateWholeToggle() {
   const channelExpression = useChannelExpression();
+  const training = useTraining();
   const checked = useSelector(channelExpression, (state) => state.context.whole);
 
   const handleToggle = () => {
     channelExpression.send({ type: 'TOGGLE_WHOLE' });
+    training.send({ type: 'TOGGLE_WHOLE' });
   };
 
   return (

--- a/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/CalculateWholeToggle.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/CalculateWholeToggle.js
@@ -1,0 +1,42 @@
+import FormControlLabel from '@mui/material/FormControlLabel';
+import FormGroup from '@mui/material/FormGroup';
+import { styled } from '@mui/material/styles';
+import Switch from '@mui/material/Switch';
+import Tooltip, { tooltipClasses } from '@mui/material/Tooltip';
+import { useSelector } from '@xstate/react';
+import { useChannelExpression } from '../../../ProjectContext';
+
+const CustomWidthTooltip = styled(({ className, ...props }) => (
+  <Tooltip {...props} classes={{ popper: className }} />
+))({
+  [`& .${tooltipClasses.tooltip}`]: {
+    maxWidth: 100,
+  },
+});
+
+function CalculateWholeToggle() {
+  const channelExpression = useChannelExpression();
+  const checked = useSelector(channelExpression, (state) => state.context.whole);
+
+  const handleToggle = () => {
+    channelExpression.send({ type: 'TOGGLE_WHOLE' });
+  };
+
+  return (
+    <FormGroup sx={{ display: 'inline' }}>
+      <CustomWidthTooltip
+        title={'If on, different cells across frames should not share cell IDs!'}
+        placement='right'
+      >
+        <FormControlLabel
+          sx={{ paddingRight: 1, color: 'rgba(0, 0, 0, 0.6)' }}
+          control={<Switch checked={checked} onChange={handleToggle} />}
+          label='All Frames'
+          labelPlacement='start'
+        />
+      </CustomWidthTooltip>
+    </FormGroup>
+  );
+}
+
+export default CalculateWholeToggle;

--- a/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/ChannelSelect.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/ChannelSelect.js
@@ -10,6 +10,7 @@ import { useRaw } from '../../../ProjectContext';
 function ChannelSelect(props) {
   const { channelX, setChannelX, channelY, setChannelY, plot, setPlot } = props;
   const raw = useRaw();
+  const numChannels = useSelector(raw, (state) => state.context.numChannels);
   const names = useSelector(raw, (state) => state.context.channelNames);
 
   const handleChangePlot = (evt) => {
@@ -32,7 +33,7 @@ function ChannelSelect(props) {
           size='small'
           value={channelX}
           label='X Channel'
-          sx={{ width: 130 }}
+          sx={{ width: '47%' }}
           onChange={handleChangeX}
         >
           {names.map((opt, index) => (
@@ -47,7 +48,7 @@ function ChannelSelect(props) {
           value={channelY}
           label='Y Channel'
           disabled={plot === 'histogram'}
-          sx={{ width: 130, marginLeft: 2 }}
+          sx={{ width: '47%', marginLeft: '3%' }}
           onChange={handleChangeY}
         >
           {names.map((opt, index) => (
@@ -57,15 +58,16 @@ function ChannelSelect(props) {
           ))}
         </TextField>
       </Grid>
-      <Grid item sx={{ marginLeft: 1.5 }}>
+      <Grid item sx={{ marginLeft: 0.5 }}>
         <FormControl>
           <RadioGroup row value={plot} onChange={handleChangePlot}>
-            <FormControlLabel value='scatter' control={<Radio />} label='Scatter' />
+            <FormControlLabel value='histogram' control={<Radio />} label='Histogram' />
             <FormControlLabel
-              value='histogram'
-              sx={{ marginLeft: 4 }}
+              sx={{ marginLeft: 5 }}
+              disabled={numChannels === 1}
+              value='scatter'
               control={<Radio />}
-              label='Histogram'
+              label='Scatter'
             />
           </RadioGroup>
         </FormControl>

--- a/frontend/src/Project/EditControls/CellTypeControls/TrainingUI/Hyperparameters.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/TrainingUI/Hyperparameters.js
@@ -7,12 +7,11 @@ import Grid from '@mui/material/Grid';
 import InputAdornment from '@mui/material/InputAdornment';
 import Slider from '@mui/material/Slider';
 import { useTheme } from '@mui/material/styles';
-import Switch from '@mui/material/Switch';
 import { useSelector } from '@xstate/react';
 import { useTraining } from '../../../ProjectContext';
-import { getCellList } from '../../../service/labels/trainingMachine';
+import CalculateWholeToggle from '../ChannelExpressionUI/CalculateWholeToggle';
 
-function Hyperparameters({ badBatch }) {
+function Hyperparameters({ badBatch, trainSize, valSize }) {
   const batches = [1, 2, 4, 8, 16, 32, 64, 128, 256];
   const epochs = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
   const lrs = [0.001, 0.01, 0.1, 1.0];
@@ -23,9 +22,6 @@ function Hyperparameters({ badBatch }) {
   const learningRate = lrs.indexOf(useSelector(training, (state) => state.context.learningRate));
   const embedding = embeddings.indexOf(useSelector(training, (state) => state.context.embedding));
   const valSplit = useSelector(training, (state) => state.context.valSplit) * 100;
-  const cellTypes = useSelector(training, (state) => state.context.cellTypes);
-  const trainSize = Math.ceil((getCellList(cellTypes).length * valSplit) / 100);
-  const valSize = getCellList(cellTypes).length - trainSize;
   const theme = useTheme();
 
   const marks = [
@@ -204,10 +200,9 @@ function Hyperparameters({ badBatch }) {
           <Chip label={valSize} />
         </Grid>
         <Grid item>
-          <FormLabel sx={{ display: 'inline-block', paddingRight: '0.5em' }}>
-            Train on all frames?
-          </FormLabel>
-          <Switch defaultChecked />
+          <Box sx={{ marginLeft: '-0.9em' }}>
+            <CalculateWholeToggle />
+          </Box>
         </Grid>
       </Grid>
     </Box>

--- a/frontend/src/Project/EditControls/CellTypeControls/TrainingUI/LearnTab.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/TrainingUI/LearnTab.js
@@ -13,7 +13,7 @@ function LearnTab() {
     if (quantities[embedding] === 'Position') {
       channelExpression.send({ type: 'CALCULATE', stat: quantities[embedding] });
     } else {
-      channelExpression.send({ type: 'CALCULATE_UMAP', stat: quantities[embedding] });
+      channelExpression.send({ type: 'CALCULATE_UMAP', stat: quantities[embedding], whole: true });
     }
   };
 

--- a/frontend/src/Project/EditControls/CellTypeControls/TrainingUI/LearnTab.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/TrainingUI/LearnTab.js
@@ -1,7 +1,8 @@
-import { Button, MenuItem, TextField } from '@mui/material';
+import { Box, Button, MenuItem, TextField } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import { useState } from 'react';
 import { useChannelExpression } from '../../../ProjectContext';
+import CalculateWholeToggle from '../ChannelExpressionUI/CalculateWholeToggle';
 import TrainingButtons from './TrainingButtons';
 
 function LearnTab() {
@@ -19,14 +20,14 @@ function LearnTab() {
 
   return (
     <>
-      <Grid item display='flex' alignItems='center' sx={{ marginLeft: 1.4, marginTop: 1 }}>
+      <Grid item display='flex'>
         <TextField
           select
           size='small'
           value={embedding}
           label='Embedding'
           onChange={(evt) => setEmbedding(evt.target.value)}
-          sx={{ width: 154.6 }}
+          sx={{ width: '47%' }}
         >
           {quantities.map((opt, index) => (
             <MenuItem key={index} value={index}>
@@ -34,11 +35,12 @@ function LearnTab() {
             </MenuItem>
           ))}
         </TextField>
-        <Button
-          sx={{ marginLeft: 2, width: 154.6, height: 35 }}
-          variant='contained'
-          onClick={handleVisualize}
-        >
+        <Box sx={{ marginLeft: '1%' }}>
+          <CalculateWholeToggle />
+        </Box>
+      </Grid>
+      <Grid item>
+        <Button sx={{ width: '97%' }} variant='contained' onClick={handleVisualize}>
           Visualize
         </Button>
       </Grid>

--- a/frontend/src/Project/EditControls/CellTypeControls/TrainingUI/LearnTab.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/TrainingUI/LearnTab.js
@@ -1,46 +1,50 @@
 import { Button, MenuItem, TextField } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import { useState } from 'react';
-import TrainingButtons from './TrainingButtons';
 import { useChannelExpression } from '../../../ProjectContext';
+import TrainingButtons from './TrainingButtons';
 
 function LearnTab() {
-    
-    const quantities = ['Mean', 'Total'];
-    const [embedding, setEmbedding] = useState(0);
-    const channelExpression = useChannelExpression();
+  const quantities = ['Position', 'Mean', 'Total'];
+  const [embedding, setEmbedding] = useState(0);
+  const channelExpression = useChannelExpression();
 
-    const handleVisualize = () => {
-        channelExpression.send({ type: 'CALCULATE_UMAP', stat: quantities[embedding] });
-    };
+  const handleVisualize = () => {
+    if (quantities[embedding] === 'Position') {
+      channelExpression.send({ type: 'CALCULATE', stat: quantities[embedding] });
+    } else {
+      channelExpression.send({ type: 'CALCULATE_UMAP', stat: quantities[embedding] });
+    }
+  };
 
-    return (
-        <>
-        <Grid item display='flex' alignItems='center' sx={{marginLeft: 1.4, marginTop: 1}}>
-            <TextField
-                select
-                size='small'
-                value={embedding}
-                label='Embedding'
-                onChange={(evt) => setEmbedding(evt.target.value)}
-                sx={{width: 154.6}}>
-                {quantities.map((opt, index) => (
-                <MenuItem key={index} value={index}>
-                    {opt}
-                </MenuItem>
-                ))}
-            </TextField>
-            <Button
-                sx={{ marginLeft: 2, width: 154.6, height: 35 }}
-                variant='contained'
-                onClick={handleVisualize}
-            >
-                Visualize
-            </Button>
-        </Grid>
-        <TrainingButtons />
-        </>
-    );
-};
+  return (
+    <>
+      <Grid item display='flex' alignItems='center' sx={{ marginLeft: 1.4, marginTop: 1 }}>
+        <TextField
+          select
+          size='small'
+          value={embedding}
+          label='Embedding'
+          onChange={(evt) => setEmbedding(evt.target.value)}
+          sx={{ width: 154.6 }}
+        >
+          {quantities.map((opt, index) => (
+            <MenuItem key={index} value={index}>
+              {opt}
+            </MenuItem>
+          ))}
+        </TextField>
+        <Button
+          sx={{ marginLeft: 2, width: 154.6, height: 35 }}
+          variant='contained'
+          onClick={handleVisualize}
+        >
+          Visualize
+        </Button>
+      </Grid>
+      <TrainingButtons />
+    </>
+  );
+}
 
 export default LearnTab;

--- a/frontend/src/Project/EditControls/CellTypeControls/TrainingUI/TrainingButtons.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/TrainingUI/TrainingButtons.js
@@ -1,6 +1,6 @@
 import InsightsIcon from '@mui/icons-material/Insights';
 import MiscellaneousServicesIcon from '@mui/icons-material/MiscellaneousServices';
-import { Box, Button } from '@mui/material';
+import { Button } from '@mui/material';
 import Grid from '@mui/material/Grid';
 import { useSelector } from '@xstate/react';
 import { useState } from 'react';
@@ -21,13 +21,11 @@ function TrainingButtons() {
   };
 
   return (
-    <Box sx={{ marginTop: 2, marginLeft: 1.8 }}>
-      <Grid item display='flex' sx={{ marginTop: 1 }}>
+    <>
+      <Grid item display='flex'>
         <Button
           sx={{
-            marginLeft: 1.55,
-            width: 154.6,
-            height: 35,
+            width: '47%',
             backgroundColor: 'rgba(245, 20, 87, 1)',
             '&:hover': { backgroundColor: 'rgba(224, 0, 67, 1)' },
           }}
@@ -40,9 +38,8 @@ function TrainingButtons() {
         <Button
           disabled={model ? false : true}
           sx={{
-            marginLeft: 2,
-            width: 154.6,
-            height: 35,
+            marginLeft: '3%',
+            width: '47%',
             backgroundColor: 'rgba(20, 200, 83, 1)',
             '&:hover': { backgroundColor: 'rgba(0, 180, 63, 1)' },
           }}
@@ -54,7 +51,7 @@ function TrainingButtons() {
         </Button>
       </Grid>
       <VisualizationModal open={open} setOpen={setOpen} />
-    </Box>
+    </>
   );
 }
 

--- a/frontend/src/Project/ProjectContext.js
+++ b/frontend/src/Project/ProjectContext.js
@@ -468,7 +468,7 @@ export function useCellsAtTime() {
   const labeled = useLabeled();
   const c = useSelector(labeled, (state) => state.context.feature);
   const cells = useCells();
-  const cellList = useMemo(() => cells.getCellsAtTime(t, c), [cells, t, c]);
+  const cellList = useMemo(() => cells.getCellsListAtTime(t, c), [cells, t, c]);
   return cellList;
 }
 

--- a/frontend/src/Project/cells.ts
+++ b/frontend/src/Project/cells.ts
@@ -85,9 +85,9 @@ class Cells {
 
   /** Returns the cells that are present in a frame at time t.
    * @param {number} t Time to get cells in.
-   * @returns List of cells
+   * @returns List of cell ids
    */
-  getCellsAtTime(t: number, c: number) {
+  getCellsListAtTime(t: number, c: number) {
     let cells = this.cells.filter((cell) => cell.t === t && cell.c === c).map((cell) => cell.cell);
     cells = [...new Set(cells)];
     cells.sort((a, b) => a - b);

--- a/frontend/src/Project/service/labels/arraysMachine.js
+++ b/frontend/src/Project/service/labels/arraysMachine.js
@@ -81,9 +81,16 @@ const createArraysMachine = (context) =>
             SET_CHANNEL: { actions: ['setChannel', 'sendRawFrame'] },
             GET_ARRAYS: { actions: 'sendArrays' },
             EDITED_SEGMENT: {
-              actions: ['setLabeledFrame', 'sendLabeledFrame', forwardTo('eventBus')],
+              actions: [
+                'setLabeledFrame',
+                'sendLabeledFrame',
+                'sendLabeledFull',
+                forwardTo('eventBus'),
+              ],
             },
-            RESTORE: { actions: ['setLabeledFrame', 'sendLabeledFrame', 'sendRestored'] },
+            RESTORE: {
+              actions: ['setLabeledFrame', 'sendLabeledFrame', 'sendLabeledFull', 'sendRestored'],
+            },
           },
         },
         editing: {
@@ -138,6 +145,13 @@ const createArraysMachine = (context) =>
           (ctx, evt) => ({
             type: 'LABELED',
             labeled: ctx.labeled[ctx.feature][ctx.t],
+          }),
+          { to: 'eventBus' }
+        ),
+        sendLabeledFull: send(
+          (ctx) => ({
+            type: 'LABELED_FULL',
+            labeled: ctx.labeled,
           }),
           { to: 'eventBus' }
         ),

--- a/frontend/src/Project/service/labels/channelExpression.test.ts
+++ b/frontend/src/Project/service/labels/channelExpression.test.ts
@@ -1,216 +1,251 @@
-import { calculateMean, calculatePosition, calculateTotal } from './channelExpressionMachine';
+import {
+  calculateMean,
+  calculateMeanWhole,
+  calculatePosition,
+  calculateTotal,
+  calculateTotalWhole,
+} from './channelExpressionMachine';
 
-test('no cells leads to empty lists', () => {
-  const ctx = {
-    t: 0,
-    feature: 0,
-    labeled: [
-      [0, 0],
-      [0, 0],
-    ],
-    raw: [
+const ctxNoCells = {
+  t: 0,
+  feature: 0,
+  labeled: [
+    [0, 0],
+    [0, 0],
+  ],
+  labeledFull: [
+    [
       [
-        [0, 1],
-        [2, 3],
-      ],
-      [
-        [0, 1],
-        [2, 3],
+        [0, 0],
+        [0, 0],
       ],
     ],
-    cells: [],
-    numCells: 0,
-  };
-  expect(calculateMean(ctx)).toEqual([[], []]);
-  expect(calculatePosition(ctx)).toEqual([[], []]);
-  expect(calculateTotal(ctx)).toEqual([[], []]);
+  ],
+  raw: [
+    [
+      [
+        [3, 2],
+        [3, 4],
+      ],
+    ],
+    [
+      [
+        [100, 100],
+        [100, 100],
+      ],
+    ],
+  ],
+  cells: [],
+  numCells: 0,
+};
+
+const ctxNonExistentCell = {
+  t: 0,
+  feature: 0,
+  labeled: [
+    [0, 0],
+    [0, 0],
+  ],
+  labeledFull: [
+    [
+      [
+        [0, 0],
+        [0, 0],
+      ],
+    ],
+  ],
+  raw: [
+    [
+      [
+        [3, 2],
+        [3, 4],
+      ],
+    ],
+    [
+      [
+        [100, 100],
+        [100, 100],
+      ],
+    ],
+  ],
+  cells: [{ cell: 0, value: 1, t: 0, c: 0 }],
+  numCells: 1,
+};
+
+const ctxOneCell = {
+  t: 0,
+  feature: 0,
+  labeled: [
+    [1, 1],
+    [1, 1],
+  ],
+  labeledFull: [
+    [
+      [
+        [1, 1],
+        [1, 1],
+      ],
+      [
+        [1, 1],
+        [1, 1],
+      ],
+    ],
+  ],
+  raw: [
+    [
+      [
+        [3, 2],
+        [3, 4],
+      ],
+      [
+        [11, 11],
+        [11, 11],
+      ],
+    ],
+    [
+      [
+        [100, 100],
+        [100, 100],
+      ],
+      [
+        [200, 200],
+        [200, 200],
+      ],
+    ],
+  ],
+  cells: [
+    { cell: 0, value: 1, t: 0, c: 0 },
+    { cell: 0, value: 1, t: 1, c: 0 },
+  ],
+  numCells: 1,
+};
+
+const ctxTwoCells = {
+  t: 0,
+  feature: 0,
+  labeled: [
+    [1, 3],
+    [1, 2],
+  ],
+  labeledFull: [
+    [
+      [
+        [1, 3],
+        [1, 2],
+      ],
+      [
+        [2, 1],
+        [2, 3],
+      ],
+    ],
+  ],
+  raw: [
+    [
+      [
+        [3, 3],
+        [3, 5],
+      ],
+      [
+        [1, 1],
+        [1, 0],
+      ],
+    ],
+    [
+      [
+        [100, 100],
+        [100, 50],
+      ],
+      [
+        [20, 20],
+        [20, 30],
+      ],
+    ],
+  ],
+  cells: [
+    { cell: 0, value: 1, t: 0, c: 0 },
+    { cell: 1, value: 2, t: 0, c: 0 },
+    { cell: 0, value: 3, t: 0, c: 0 },
+    { cell: 1, value: 3, t: 0, c: 0 },
+    { cell: 0, value: 1, t: 1, c: 0 },
+    { cell: 1, value: 2, t: 1, c: 0 },
+    { cell: 0, value: 3, t: 1, c: 0 },
+    { cell: 1, value: 3, t: 1, c: 0 },
+  ],
+  numCells: 2,
+};
+
+test('no cells leads to empty lists one frame', () => {
+  expect(calculateMean(ctxNoCells)).toEqual([[], []]);
+  expect(calculatePosition(ctxNoCells)).toEqual([[], []]);
+  expect(calculateTotal(ctxNoCells)).toEqual([[], []]);
 });
 
-test('non-existent cell leads to NaNs', () => {
-  const ctx = {
-    t: 0,
-    feature: 0,
-    labeled: [
-      [0, 0],
-      [0, 0],
-    ],
-    raw: [
-      [
-        [0, 1],
-        [2, 3],
-      ],
-      [
-        [0, 1],
-        [2, 3],
-      ],
-    ],
-    cells: [{ cell: 0, value: 1, t: 0, c: 0 }],
-    numCells: 1,
-  };
-  expect(calculateMean(ctx)).toEqual([[NaN], [NaN]]);
-  expect(calculateTotal(ctx)).toEqual([[NaN], [NaN]]);
-  expect(calculatePosition(ctx)).toEqual([[NaN], [NaN]]);
+test('no cells leads to empty lists cross-frame', () => {
+  expect(calculateMeanWhole(ctxNoCells)).toEqual([[], []]);
+  expect(calculateTotalWhole(ctxNoCells)).toEqual([[], []]);
 });
 
-test('one cell calculates mean', () => {
-  const ctx = {
-    t: 0,
-    feature: 0,
-    labeled: [
-      [1, 1],
-      [1, 1],
-    ],
-    raw: [
-      [
-        [
-          [3, 2],
-          [3, 4],
-        ],
-      ],
-      [
-        [
-          [100, 100],
-          [100, 100],
-        ],
-      ],
-    ],
-    cells: [{ cell: 0, value: 1, t: 0, c: 0 }],
-    numCells: 1,
-  };
-  expect(calculateMean(ctx)).toEqual([[3], [100]]);
+test('non-existent cell leads to NaNs one frame', () => {
+  expect(calculateMean(ctxNonExistentCell)).toEqual([[NaN], [NaN]]);
+  expect(calculateTotal(ctxNonExistentCell)).toEqual([[NaN], [NaN]]);
+  expect(calculatePosition(ctxNonExistentCell)).toEqual([[NaN], [NaN]]);
 });
 
-test('one cell calculates total', () => {
-  const ctx = {
-    t: 0,
-    feature: 0,
-    labeled: [
-      [1, 1],
-      [1, 1],
-    ],
-    raw: [
-      [
-        [
-          [3, 2],
-          [3, 4],
-        ],
-      ],
-      [
-        [
-          [100, 100],
-          [100, 100],
-        ],
-      ],
-    ],
-    cells: [{ cell: 0, value: 1, t: 0, c: 0 }],
-    numCells: 1,
-  };
-  expect(calculateTotal(ctx)).toEqual([[12], [400]]);
+test('non-existent cell leads to NaNs cross-frame', () => {
+  expect(calculateMeanWhole(ctxNonExistentCell)).toEqual([[NaN], [NaN]]);
+  expect(calculateTotalWhole(ctxNonExistentCell)).toEqual([[NaN], [NaN]]);
+});
+
+test('one cell calculates mean one frame', () => {
+  expect(calculateMean(ctxOneCell)).toEqual([[3], [100]]);
+});
+
+test('one cell calculates mean cross-frame', () => {
+  expect(calculateMeanWhole(ctxOneCell)).toEqual([[7], [150]]);
+});
+
+test('one cell calculates total one frame', () => {
+  expect(calculateTotal(ctxOneCell)).toEqual([[12], [400]]);
+});
+
+test('one cell calculates total cross-frame', () => {
+  expect(calculateTotalWhole(ctxOneCell)).toEqual([[56], [1200]]);
 });
 
 test('one cell calculates position', () => {
-  const ctx = {
-    t: 0,
-    feature: 0,
-    labeled: [
-      [1, 1],
-      [1, 1],
-    ],
-    cells: [{ cell: 0, value: 1, t: 0, c: 0 }],
-    numCells: 1,
-  };
-  expect(calculatePosition(ctx)).toEqual([[0.5], [0.5]]);
+  expect(calculatePosition(ctxOneCell)).toEqual([[0.5], [0.5]]);
 });
 
-test('two overlapping cells calculate mean', () => {
-  const ctx = {
-    t: 0,
-    feature: 0,
-    labeled: [
-      [1, 3],
-      [1, 2],
-    ],
-    raw: [
-      [
-        [
-          [3, 3],
-          [3, 5],
-        ],
-      ],
-      [
-        [
-          [100, 100],
-          [100, 50],
-        ],
-      ],
-    ],
-    cells: [
-      { cell: 0, value: 1, t: 0, c: 0 },
-      { cell: 1, value: 2, t: 0, c: 0 },
-      { cell: 0, value: 3, t: 0, c: 0 },
-      { cell: 1, value: 3, t: 0, c: 0 },
-    ],
-    numCells: 2,
-  };
-  expect(calculateMean(ctx)).toEqual([
+test('two overlapping cells calculate mean one frame', () => {
+  expect(calculateMean(ctxTwoCells)).toEqual([
     [3, 4],
     [100, 75],
   ]);
 });
 
-test('two overlapping cells calculate total', () => {
-  const ctx = {
-    t: 0,
-    feature: 0,
-    labeled: [
-      [1, 3],
-      [1, 2],
-    ],
-    raw: [
-      [
-        [
-          [3, 3],
-          [3, 5],
-        ],
-      ],
-      [
-        [
-          [100, 100],
-          [100, 50],
-        ],
-      ],
-    ],
-    cells: [
-      { cell: 0, value: 1, t: 0, c: 0 },
-      { cell: 1, value: 2, t: 0, c: 0 },
-      { cell: 0, value: 3, t: 0, c: 0 },
-      { cell: 1, value: 3, t: 0, c: 0 },
-    ],
-    numCells: 2,
-  };
-  expect(calculateTotal(ctx)).toEqual([
+test('two overlapping cells calculate mean cross-frame', () => {
+  expect(calculateMeanWhole(ctxTwoCells)).toEqual([
+    [2, 2],
+    [70, 44],
+  ]);
+});
+
+test('two overlapping cells calculate total one frame', () => {
+  expect(calculateTotal(ctxTwoCells)).toEqual([
     [9, 8],
     [300, 150],
   ]);
 });
 
+test('two overlapping cells calculate total cross-frame', () => {
+  expect(calculateTotalWhole(ctxTwoCells)).toEqual([
+    [10, 10],
+    [350, 220],
+  ]);
+});
+
 test('two overlapping cells calculate position', () => {
-  const ctx = {
-    t: 0,
-    feature: 0,
-    labeled: [
-      [1, 3],
-      [1, 2],
-    ],
-    cells: [
-      { cell: 0, value: 1, t: 0, c: 0 },
-      { cell: 1, value: 2, t: 0, c: 0 },
-      { cell: 0, value: 3, t: 0, c: 0 },
-      { cell: 1, value: 3, t: 0, c: 0 },
-    ],
-    numCells: 2,
-  };
-  expect(calculatePosition(ctx)).toEqual([
+  expect(calculatePosition(ctxTwoCells)).toEqual([
     [1 / 3, 1],
     [2 / 3, 0.5],
   ]);

--- a/frontend/src/Project/service/labels/channelExpression.test.ts
+++ b/frontend/src/Project/service/labels/channelExpression.test.ts
@@ -1,0 +1,217 @@
+import { calculateMean, calculatePosition, calculateTotal } from './channelExpressionMachine';
+
+test('no cells leads to empty lists', () => {
+  const ctx = {
+    t: 0,
+    feature: 0,
+    labeled: [
+      [0, 0],
+      [0, 0],
+    ],
+    raw: [
+      [
+        [0, 1],
+        [2, 3],
+      ],
+      [
+        [0, 1],
+        [2, 3],
+      ],
+    ],
+    cells: [],
+    numCells: 0,
+  };
+  expect(calculateMean(ctx)).toEqual([[], []]);
+  expect(calculatePosition(ctx)).toEqual([[], []]);
+  expect(calculateTotal(ctx)).toEqual([[], []]);
+});
+
+test('non-existent cell leads to NaNs', () => {
+  const ctx = {
+    t: 0,
+    feature: 0,
+    labeled: [
+      [0, 0],
+      [0, 0],
+    ],
+    raw: [
+      [
+        [0, 1],
+        [2, 3],
+      ],
+      [
+        [0, 1],
+        [2, 3],
+      ],
+    ],
+    cells: [{ cell: 0, value: 1, t: 0, c: 0 }],
+    numCells: 1,
+  };
+  expect(calculateMean(ctx)).toEqual([[NaN], [NaN]]);
+  expect(calculateTotal(ctx)).toEqual([[NaN], [NaN]]);
+  expect(calculatePosition(ctx)).toEqual([[NaN], [NaN]]);
+});
+
+test('one cell calculates mean', () => {
+  const ctx = {
+    t: 0,
+    feature: 0,
+    labeled: [
+      [1, 1],
+      [1, 1],
+    ],
+    raw: [
+      [
+        [
+          [3, 2],
+          [3, 4],
+        ],
+      ],
+      [
+        [
+          [100, 100],
+          [100, 100],
+        ],
+      ],
+    ],
+    cells: [{ cell: 0, value: 1, t: 0, c: 0 }],
+    numCells: 1,
+  };
+  expect(calculateMean(ctx)).toEqual([[3], [100]]);
+});
+
+test('one cell calculates total', () => {
+  const ctx = {
+    t: 0,
+    feature: 0,
+    labeled: [
+      [1, 1],
+      [1, 1],
+    ],
+    raw: [
+      [
+        [
+          [3, 2],
+          [3, 4],
+        ],
+      ],
+      [
+        [
+          [100, 100],
+          [100, 100],
+        ],
+      ],
+    ],
+    cells: [{ cell: 0, value: 1, t: 0, c: 0 }],
+    numCells: 1,
+  };
+  expect(calculateTotal(ctx)).toEqual([[12], [400]]);
+});
+
+test('one cell calculates position', () => {
+  const ctx = {
+    t: 0,
+    feature: 0,
+    labeled: [
+      [1, 1],
+      [1, 1],
+    ],
+    cells: [{ cell: 0, value: 1, t: 0, c: 0 }],
+    numCells: 1,
+  };
+  expect(calculatePosition(ctx)).toEqual([[0.5], [0.5]]);
+});
+
+test('two overlapping cells calculate mean', () => {
+  const ctx = {
+    t: 0,
+    feature: 0,
+    labeled: [
+      [1, 3],
+      [1, 2],
+    ],
+    raw: [
+      [
+        [
+          [3, 3],
+          [3, 5],
+        ],
+      ],
+      [
+        [
+          [100, 100],
+          [100, 50],
+        ],
+      ],
+    ],
+    cells: [
+      { cell: 0, value: 1, t: 0, c: 0 },
+      { cell: 1, value: 2, t: 0, c: 0 },
+      { cell: 0, value: 3, t: 0, c: 0 },
+      { cell: 1, value: 3, t: 0, c: 0 },
+    ],
+    numCells: 2,
+  };
+  expect(calculateMean(ctx)).toEqual([
+    [3, 4],
+    [100, 75],
+  ]);
+});
+
+test('two overlapping cells calculate total', () => {
+  const ctx = {
+    t: 0,
+    feature: 0,
+    labeled: [
+      [1, 3],
+      [1, 2],
+    ],
+    raw: [
+      [
+        [
+          [3, 3],
+          [3, 5],
+        ],
+      ],
+      [
+        [
+          [100, 100],
+          [100, 50],
+        ],
+      ],
+    ],
+    cells: [
+      { cell: 0, value: 1, t: 0, c: 0 },
+      { cell: 1, value: 2, t: 0, c: 0 },
+      { cell: 0, value: 3, t: 0, c: 0 },
+      { cell: 1, value: 3, t: 0, c: 0 },
+    ],
+    numCells: 2,
+  };
+  expect(calculateTotal(ctx)).toEqual([
+    [9, 8],
+    [300, 150],
+  ]);
+});
+
+test('two overlapping cells calculate position', () => {
+  const ctx = {
+    t: 0,
+    feature: 0,
+    labeled: [
+      [1, 3],
+      [1, 2],
+    ],
+    cells: [
+      { cell: 0, value: 1, t: 0, c: 0 },
+      { cell: 1, value: 2, t: 0, c: 0 },
+      { cell: 0, value: 3, t: 0, c: 0 },
+      { cell: 1, value: 3, t: 0, c: 0 },
+    ],
+    numCells: 2,
+  };
+  expect(calculatePosition(ctx)).toEqual([
+    [1 / 3, 1],
+    [2 / 3, 0.5],
+  ]);
+});

--- a/frontend/src/Project/service/labels/channelExpressionMachine.js
+++ b/frontend/src/Project/service/labels/channelExpressionMachine.js
@@ -240,7 +240,7 @@ const createChannelExpressionMachine = ({ eventBuses }) =>
         feature: 0,
         labeled: null, // currently displayed labeled frame (Int32Array[][])
         labeledFull: null,
-        whole: null,
+        whole: false,
         raw: null, // current displayed raw frame (?Array[][])
         cells: null,
         numCells: null,
@@ -290,6 +290,7 @@ const createChannelExpressionMachine = ({ eventBuses }) =>
           states: {
             idle: {
               on: {
+                TOGGLE_WHOLE: { actions: 'toggleWhole' },
                 CALCULATE: { target: 'calculating' },
                 CALCULATE_UMAP: { target: 'visualizing' },
               },
@@ -297,19 +298,19 @@ const createChannelExpressionMachine = ({ eventBuses }) =>
             calculating: {
               entry: choose([
                 {
-                  cond: (_, evt) => evt.stat === 'Mean' && evt.whole === false,
+                  cond: (ctx, evt) => evt.stat === 'Mean' && !ctx.whole,
                   actions: ['setStat', 'calculateMean'],
                 },
                 {
-                  cond: (_, evt) => evt.stat === 'Total' && evt.whole === false,
+                  cond: (ctx, evt) => evt.stat === 'Total' && !ctx.whole,
                   actions: ['setStat', 'calculateTotal'],
                 },
                 {
-                  cond: (_, evt) => evt.stat === 'Mean' && evt.whole === true,
+                  cond: (ctx, evt) => evt.stat === 'Mean' && ctx.whole,
                   actions: ['setStat', 'calculateMeanWhole'],
                 },
                 {
-                  cond: (_, evt) => evt.stat === 'Total' && evt.whole === true,
+                  cond: (ctx, evt) => evt.stat === 'Total' && ctx.whole,
                   actions: ['setStat', 'calculateTotalWhole'],
                 },
                 {
@@ -322,19 +323,19 @@ const createChannelExpressionMachine = ({ eventBuses }) =>
             visualizing: {
               entry: choose([
                 {
-                  cond: (_, evt) => evt.stat === 'Mean' && evt.whole === false,
+                  cond: (ctx, evt) => evt.stat === 'Mean' && !ctx.whole,
                   actions: ['setStat', 'calculateMean'],
                 },
                 {
-                  cond: (_, evt) => evt.stat === 'Total' && evt.whole === false,
+                  cond: (ctx, evt) => evt.stat === 'Total' && !ctx.whole,
                   actions: ['setStat', 'calculateTotal'],
                 },
                 {
-                  cond: (_, evt) => evt.stat === 'Mean' && evt.whole === true,
+                  cond: (ctx, evt) => evt.stat === 'Mean' && ctx.whole,
                   actions: ['setStat', 'calculateMeanWhole'],
                 },
                 {
-                  cond: (_, evt) => evt.stat === 'Total' && evt.whole === true,
+                  cond: (ctx, evt) => evt.stat === 'Total' && ctx.whole,
                   actions: ['setStat', 'calculateTotalWhole'],
                 },
               ]),
@@ -359,6 +360,7 @@ const createChannelExpressionMachine = ({ eventBuses }) =>
         setT: assign({ t: (_, evt) => evt.t }),
         setFeature: assign({ feature: (_, evt) => evt.feature }),
         setStat: assign({ calculation: (_, evt) => evt.stat }),
+        toggleWhole: assign({ whole: (ctx) => !ctx.whole }),
         calculateMean: pure((ctx) => {
           const channelMeans = calculateMean(ctx);
           return [

--- a/frontend/src/Project/service/labels/trainingMachine.js
+++ b/frontend/src/Project/service/labels/trainingMachine.js
@@ -3,6 +3,7 @@
 
 import * as tf from '@tensorflow/tfjs';
 import { actions, assign, Machine, send } from 'xstate';
+import Cells from '../../cells';
 import { fromEventBus } from '../eventBus';
 
 const { choose } = actions;
@@ -23,23 +24,50 @@ export function argMax(arr) {
   return maxIndex;
 }
 
+/** Get list of labels for a given cell
+ * @param {Array} cellTypes List of cell type objects
+ * @param {Array} cells A cell's ID
+ * @returns List of cell type labels for a given cell
+ */
 export function getLabelsFromCell(cellTypes, cell) {
   const types = cellTypes.filter((cellType) => cellType.cell.includes(cell));
   const labels = types.map((cellType) => cellType.id);
   return labels;
 }
 
+/** Assuming that each cell only has one label, finds a cell's label
+ * @param {Array} cellTypes List of cell type objects
+ * @param {Array} cell A cell's ID
+ * @returns Cell type label of given cell
+ */
 export function getLabelFromCell(cellTypes, cell) {
-  // Assuming that there is only one label per cell
   const type = cellTypes.filter((cellType) => cellType.cells.includes(cell))[0];
   return type.id;
 }
 
+/** Get list of all labeled cells
+ * @param {Array} cellTypes List of cell type objects
+ * @returns List of cells with labeled cell types across all frames
+ */
 export function getCellList(cellTypes) {
   const cellsList = cellTypes.map((cellType) => cellType.cells).flat();
   return [...new Set(cellsList)];
 }
 
+/** Get list of labeled cells at current time
+ * @param {Array} cellTypes List of cell type objects
+ * @param {Array} cellsAtTime List of cells at current frame
+ * @returns List of cells with labeled cell types at current frame
+ */
+export function getCellListAtTime(cellTypes, cellsAtTime) {
+  const cellsList = getCellList(cellTypes);
+  const cellsListAtTime = cellsList.filter((cell) => cellsAtTime.includes(cell));
+  return cellsListAtTime;
+}
+
+/** Consolidate embedding and labeled cells into a tensor ready for training
+ * @returns Tensors for training and validation data / labels, normalization range
+ */
 function convertToTensor(cells, embedding, cellTypes, maxId, valSplit) {
   // Convert cells and embedding lists into tensors
 
@@ -81,6 +109,12 @@ function convertToTensor(cells, embedding, cellTypes, maxId, valSplit) {
   });
 }
 
+/** Calculates the unlabeled cells to consider and predict on
+ * @param {array} cells List of all cells or cells on current frame
+ * @param {array} embedding Array with embedding for each cell in cells
+ * @returns Array describing if each cell is labeled or not and a corresponding
+ * tensor containing the relevant embeddings
+ */
 function getUnlabeledTensor(cells, embedding) {
   const unlabeled = embedding.map((vector, cell) =>
     cells.includes(cell) || vector.every((c) => isNaN(c)) ? false : true
@@ -95,6 +129,11 @@ function getUnlabeledTensor(cells, embedding) {
   };
 }
 
+/** Calculate a prediction map giving predictions and unlabeled cell ids
+ * @param {array} pred Array of predicted cell classes "probabilities"
+ * @param {array} unlabeled Array of unlabeled cell ids
+ * @returns Prediction map between cell id and cell type id prediction
+ */
 function getPredictions(pred, unlabeled) {
   const predArr = pred.arraySync();
   let j = 0;
@@ -108,6 +147,11 @@ function getPredictions(pred, unlabeled) {
   return predMap;
 }
 
+/** Use embedding size and number of classes, instantiate a model
+ * @param {number} inputShape embedding size
+ * @param {number} units number of classes that can be predicted
+ * @returns Instantiated tfjs model
+ */
 function createModel(inputShape, units) {
   // Sequential model
   const model = tf.sequential();
@@ -119,6 +163,10 @@ function createModel(inputShape, units) {
   return model;
 }
 
+/** Given hyperparameters and an instantiated model, train the model for the
+ * specified number of epochs.
+ * @returns Promise containing the trained model.
+ */
 async function trainModel(
   model,
   trainInputs,
@@ -150,6 +198,12 @@ async function trainModel(
   });
 }
 
+/** Use trained model to calculate confusion matrix on validation data
+ * @param {model} model The saved model trained in tfjs
+ * @param {tensor} valInputs The validation input data (X)
+ * @param {tensor} valLabels The validation labels (Y)
+ * @returns Normalized confusion matrix in array form
+ */
 function calculateConfusion(model, valInputs, valLabels) {
   const pred = model.predict(valInputs);
   const numClasses = valLabels.arraySync()[0].length;
@@ -165,29 +219,64 @@ function calculateConfusion(model, valInputs, valLabels) {
   return normalized;
 }
 
+/** Starts training a model using the currently labeled cell type data
+ * @param {number} batchSize Size of each batch used in training
+ * @param {list} calculations (X, Y) where X is embedding size, Y is number of cells
+ * @param {list} cells List of cell objects that are being considered
+ * @param {list} cellTypes List of cell type objects
+ * @param {number} feature Current segmentation mask
+ * @param {number} learningRate LR parameter used for optimizer
+ * @param {number} numChannels Number of channels / embedding size
+ * @param {number} numEpochs How many epochs to train for
+ * @param {number} t Current "time" frame
+ * @param {number} valSplit Decimal representing percent of data to use in training instead of testing
+ * @param {boolean} whole Whether to consider cells across all frames or just this frame
+ * @returns Sends message with object mapping cell ids to cell type id predictions
+ */
 async function train(ctx, evt, sendBack) {
+  const {
+    batchSize,
+    calculations,
+    cells,
+    cellTypes,
+    feature,
+    learningRate,
+    numChannels,
+    numEpochs,
+    t,
+    valSplit,
+    whole,
+  } = ctx;
+  const cellsAtTime = new Cells(cells).getCellsListAtTime(t, feature);
+
+  // Reorder calculations into training set format
   let vectors = [];
-  for (let i = 0; i < ctx.calculations[0].length; i++) {
+  for (let i = 0; i < calculations[0].length; i++) {
     let vector = [];
-    for (let c = 0; c < ctx.numChannels; c++) {
-      vector.push(ctx.calculations[c][i]);
+    for (let c = 0; c < numChannels; c++) {
+      vector.push(calculations[c][i]);
     }
     vectors.push(vector);
   }
-  const cells = getCellList(ctx.cellTypes);
-  const ids = ctx.cellTypes.map((cellType) => cellType.id);
+
+  // Get the list of labeled cells to train on and number of cell types
+  const cellList = whole ? getCellList(cellTypes) : getCellListAtTime(cellTypes, cellsAtTime);
+  const ids = cellTypes.map((cellType) => cellType.id);
   let maxId = 0;
   if (ids.length > 0) {
     maxId = Math.max.apply(null, ids);
   }
+
+  // Consolidate input and calculated data into Tensor
   const { trainInputs, trainLabels, valInputs, valLabels, inputMax, inputMin } = convertToTensor(
-    cells,
+    cellList,
     vectors,
-    ctx.cellTypes,
+    cellTypes,
     maxId,
-    ctx.valSplit
+    valSplit
   );
 
+  // Instantiate and train the model with the given parameters
   const model = createModel([trainInputs.shape[1]], trainLabels.shape[1]);
   await trainModel(
     model,
@@ -196,12 +285,15 @@ async function train(ctx, evt, sendBack) {
     valInputs,
     valLabels,
     sendBack,
-    ctx.batchSize,
-    ctx.numEpochs,
-    ctx.learningRate
+    batchSize,
+    numEpochs,
+    learningRate
   );
+
+  // Calculate final confusion matrix using the validation set
   const confusionMatrix = calculateConfusion(model, valInputs, valLabels);
-  // Finish by sending the trained model back to parent
+
+  // Finish by sending the trained model back to machine
   sendBack({
     type: 'DONE',
     model: model,
@@ -211,22 +303,46 @@ async function train(ctx, evt, sendBack) {
   });
 }
 
-async function predict(ctx, evt) {
+/** Using the last saved trained model, predicts cell type labels
+ * for all unlabeled cells in either the current frame or all frames
+ * @param {list} calculations (X, Y) where X is embedding size, Y is number of cells
+ * @param {list} cells List of cell objects that are being considered
+ * @param {list} cellTypes List of cell type objects
+ * @param {number} feature Current segmentation mask
+ * @param {model} model Last saved model trained by tfjs
+ * @param {number} numChannels Number of channels / embedding size
+ * @param {tuple} range Min and max used for normalization
+ * @param {number} t Current "time" frame
+ * @param {boolean} whole Whether to consider cells across all frames or just this frame
+ * @returns Sends message with object mapping cell ids to cell type id predictions
+ */
+async function predict(ctx, evt, sendBack) {
+  const { calculations, cells, cellTypes, feature, model, numChannels, range, t, whole } = ctx;
+  const cellsAtTime = new Cells(cells).getCellsListAtTime(t, feature);
+  const [inputMin, inputMax] = range;
+
+  // Reorder calculations into training set format
   let vectors = [];
-  for (let i = 0; i < ctx.calculations[0].length; i++) {
+  for (let i = 0; i < calculations[0].length; i++) {
     let vector = [];
-    for (let c = 0; c < ctx.numChannels; c++) {
+    for (let c = 0; c < numChannels; c++) {
       vector.push(ctx.calculations[c][i]);
     }
     vectors.push(vector);
   }
-  const [inputMin, inputMax] = ctx.range;
-  const cells = getCellList(ctx.cellTypes);
-  const { unlabeled, unlabeledTensor } = getUnlabeledTensor(cells, vectors);
+
+  // Get the list of unlabeled cells to train on and consolidate into normalized Tensor
+  const cellList = whole ? getCellList(cellTypes) : getCellListAtTime(cellTypes, cellsAtTime);
+  const { unlabeled, unlabeledTensor } = getUnlabeledTensor(cellList, vectors);
   const normalized = unlabeledTensor.sub(inputMin).div(inputMax.sub(inputMin));
-  const pred = ctx.model.predict(normalized);
+
+  // Use saved model to predict on unlabeled cells and send to machine
+  const pred = model.predict(normalized);
   const predMap = await getPredictions(pred, unlabeled);
-  return predMap;
+  sendBack({
+    type: 'DONE',
+    predMap: predMap,
+  });
 }
 
 const createTrainingMachine = ({ eventBuses }) =>
@@ -237,6 +353,7 @@ const createTrainingMachine = ({ eventBuses }) =>
         { id: 'eventBus', src: fromEventBus('training', () => eventBuses.training) },
         { id: 'load', src: fromEventBus('training', () => eventBuses.load, 'LOADED') },
         { id: 'cellTypes', src: fromEventBus('training', () => eventBuses.cellTypes) },
+        { id: 'cells', src: fromEventBus('training', () => eventBuses.cells, 'CELLS') },
         {
           id: 'channelExpression',
           src: fromEventBus('training', () => eventBuses.channelExpression),
@@ -245,57 +362,44 @@ const createTrainingMachine = ({ eventBuses }) =>
         { src: fromEventBus('training', () => eventBuses.labeled, 'SET_FEATURE') },
       ],
       context: {
-        embedding: 'Mean',
+        // Hyperparameters
         batchSize: 1,
         numEpochs: 20,
         learningRate: 0.01,
         valSplit: 0.8,
-        confusionMatrix: null,
+        // "Input" context
+        embedding: 'Mean',
         t: 0,
         feature: 0,
+        cells: null,
         epoch: 0,
-        range: null,
         numChannels: null, // from raw
         cellTypes: null,
         calculations: null,
+        whole: false,
+        // "Output" context
+        confusionMatrix: null,
+        range: null,
         model: null,
         valLogs: [],
         trainLogs: [],
+        parameterLog: null,
       },
       initial: 'loading',
       on: {
+        CELLS: { actions: 'setCells' },
         CELLTYPES: { actions: 'setCellTypes' },
         SET_T: { actions: 'setT' },
         SET_FEATURE: { actions: 'setFeature' },
       },
       states: {
         loading: {
-          type: 'parallel',
-          states: {
-            getCellTypes: {
-              initial: 'waiting',
-              states: {
-                waiting: {
-                  on: {
-                    LOADED: { actions: 'setCellTypes', target: 'done' },
-                  },
-                },
-                done: { type: 'final' },
-              },
-            },
-            getRaw: {
-              initial: 'waiting',
-              states: {
-                waiting: {
-                  on: {
-                    LOADED: { actions: 'setNumChannels', target: 'done' },
-                  },
-                },
-                done: { type: 'final' },
-              },
+          on: {
+            LOADED: {
+              actions: ['setCellTypes', 'setCells', 'setNumChannels'],
+              target: 'loaded',
             },
           },
-          onDone: { target: 'loaded' },
         },
         loaded: {
           initial: 'idle',
@@ -309,6 +413,7 @@ const createTrainingMachine = ({ eventBuses }) =>
                 LEARNING_RATE: { actions: 'setLearningRate' },
                 NUM_EPOCHS: { actions: 'setNumEpochs' },
                 VAL_SPLIT: { actions: 'setValSplit' },
+                TOGGLE_WHOLE: { actions: 'toggleWhole' },
               },
             },
             training: {
@@ -352,25 +457,39 @@ const createTrainingMachine = ({ eventBuses }) =>
               },
             },
             predicting: {
-              //  entry: choose([
-              //    {
-              //      cond: (ctx) => ctx.embedding === 'Mean',
-              //      actions: 'getMean',
-              //    },
-              //    {
-              //      cond: (ctx) => ctx.embedding === 'Total',
-              //      actions: 'getTotal',
-              //    },
-              //  ]),
-              invoke: {
-                id: 'predicting',
-                src: predict,
-                onDone: {
+              initial: 'calculating',
+              states: {
+                calculating: {
+                  entry: choose([
+                    {
+                      cond: (ctx) => ctx.embedding === 'Mean',
+                      actions: 'getMean',
+                    },
+                    {
+                      cond: (ctx) => ctx.embedding === 'Total',
+                      actions: 'getTotal',
+                    },
+                  ]),
+                  on: {
+                    CALCULATION: { actions: 'setCalculation', target: 'predict' },
+                  },
+                },
+                predict: {
+                  invoke: {
+                    id: 'predicting',
+                    src: (ctx, evt) => (sendBack) => {
+                      // TO-DO: handle errors in the predicting function
+                      predict(ctx, evt, sendBack);
+                    },
+                    // onError: { target: 'idle', actions: (c, e) => console.log(c, e) },
+                  },
+                },
+              },
+              on: {
+                DONE: {
                   target: 'idle',
                   actions: 'sendPredictions',
                 },
-                // TODO: send error message to parent and display in UI
-                onError: { target: 'idle', actions: ['sendApiError', (c, e) => console.log(c, e)] },
               },
             },
           },
@@ -380,6 +499,9 @@ const createTrainingMachine = ({ eventBuses }) =>
     {
       actions: {
         setBatchSize: assign({ batchSize: (_, evt) => evt.batchSize }),
+        setCells: assign({
+          cells: (ctx, evt) => evt.cells,
+        }),
         setEmbedding: assign({ embedding: (_, evt) => evt.embedding }),
         setNumEpochs: assign({ numEpochs: (_, evt) => evt.numEpochs }),
         setLearningRate: assign({ learningRate: (_, evt) => evt.learningRate }),
@@ -395,10 +517,8 @@ const createTrainingMachine = ({ eventBuses }) =>
         }),
         setCalculation: assign({ calculations: (_, evt) => evt.calculations }),
         setConfusionMatrix: assign({ confusionMatrix: (_, evt) => evt.confusionMatrix }),
-        getMean: send(
-          { type: 'CALCULATE', stat: 'Mean', whole: true },
-          { to: 'channelExpression' }
-        ),
+        toggleWhole: assign({ whole: (ctx) => !ctx.whole }),
+        getMean: send({ type: 'CALCULATE', stat: 'Mean' }, { to: 'channelExpression' }),
         getTotal: send({ type: 'CALCULATE', stat: 'Total' }, { to: 'channelExpression' }),
         resetLogs: assign({
           valLogs: [],
@@ -407,7 +527,7 @@ const createTrainingMachine = ({ eventBuses }) =>
         resetEpoch: assign({ epoch: () => 0 }),
         saveModel: assign({ model: (_, evt) => evt.model }),
         setRange: assign({ range: (_, evt) => [evt.inputMin, evt.inputMax] }),
-        sendPredictions: send((_, evt) => ({ type: 'ADD_PREDICTIONS', predictions: evt.data }), {
+        sendPredictions: send((_, evt) => ({ type: 'ADD_PREDICTIONS', predictions: evt.predMap }), {
           to: 'cellTypes',
         }),
       },

--- a/frontend/src/Project/service/labels/trainingMachine.js
+++ b/frontend/src/Project/service/labels/trainingMachine.js
@@ -1,8 +1,8 @@
 /** Perform tensorflow.js training using embeddings and labeled cell types as input data
  */
 
-import { actions, assign, Machine, send } from 'xstate';
 import * as tf from '@tensorflow/tfjs';
+import { actions, assign, Machine, send } from 'xstate';
 import { fromEventBus } from '../eventBus';
 
 const { choose } = actions;
@@ -395,7 +395,10 @@ const createTrainingMachine = ({ eventBuses }) =>
         }),
         setCalculation: assign({ calculations: (_, evt) => evt.calculations }),
         setConfusionMatrix: assign({ confusionMatrix: (_, evt) => evt.confusionMatrix }),
-        getMean: send({ type: 'CALCULATE', stat: 'Mean' }, { to: 'channelExpression' }),
+        getMean: send(
+          { type: 'CALCULATE', stat: 'Mean', whole: true },
+          { to: 'channelExpression' }
+        ),
         getTotal: send({ type: 'CALCULATE', stat: 'Total' }, { to: 'channelExpression' }),
         resetLogs: assign({
           valLogs: [],

--- a/frontend/src/Project/service/labels/trainingMachine.js
+++ b/frontend/src/Project/service/labels/trainingMachine.js
@@ -221,9 +221,9 @@ function calculateConfusion(model, valInputs, valLabels) {
 
 /** Starts training a model using the currently labeled cell type data
  * @param {number} batchSize Size of each batch used in training
- * @param {list} calculations (X, Y) where X is embedding size, Y is number of cells
- * @param {list} cells List of cell objects that are being considered
- * @param {list} cellTypes List of cell type objects
+ * @param {array} calculations (X, Y) where X is embedding size, Y is number of cells
+ * @param {array} cells List of cell objects that are being considered
+ * @param {array} cellTypes List of cell type objects
  * @param {number} feature Current segmentation mask
  * @param {number} learningRate LR parameter used for optimizer
  * @param {number} numChannels Number of channels / embedding size
@@ -305,9 +305,9 @@ async function train(ctx, evt, sendBack) {
 
 /** Using the last saved trained model, predicts cell type labels
  * for all unlabeled cells in either the current frame or all frames
- * @param {list} calculations (X, Y) where X is embedding size, Y is number of cells
- * @param {list} cells List of cell objects that are being considered
- * @param {list} cellTypes List of cell type objects
+ * @param {array} calculations (X, Y) where X is embedding size, Y is number of cells
+ * @param {array} cells List of cell objects that are being considered
+ * @param {array} cellTypes List of cell type objects
  * @param {number} feature Current segmentation mask
  * @param {model} model Last saved model trained by tfjs
  * @param {number} numChannels Number of channels / embedding size


### PR DESCRIPTION
## What
Addresses #413
* Implemented functions to calculate and visualize mean/total embeddings across all frames
* Implemented UI controls that allow users to specify whether they want to calculate/visualize/train/predict on the current frame or across all frames
* Added documentation to trainingMachine functions since those functions are a bit of a mess
* Added unit tests for new cross-frame calculation functions