### PR TITLE
Add log y scale button for histogram and save layout changes

### DIFF
--- a/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/ChannelPlot.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/ChannelPlot.js
@@ -1,5 +1,6 @@
 import Grid from '@mui/material/Grid';
 import { useSelector } from '@xstate/react';
+import { useState } from 'react';
 import Plot from 'react-plotly.js';
 import {
   useCellTypes,
@@ -49,6 +50,49 @@ function ChannelPlot({ calculations, channelX, channelY, plot }) {
     editCellTypes.send({ type: 'MULTISELECTION', selected: [cell] });
   };
 
+  // Save the layout states so that zooming does not get reset on other changes, for example
+  const [histLayout, setHistLayout] = useState({
+    bargap: 0.1,
+    width: 345,
+    height: 350,
+    margin: { l: 30, r: 20, b: 30, t: 30, pad: 5 },
+    title: { text: stat },
+    xaxis: { automargin: true, title: names[channelX] },
+    updatemenus: [
+      {
+        buttons: [
+          {
+            args: ['yaxis', {}],
+            label: 'Raw Y',
+            method: 'relayout',
+          },
+          {
+            args: ['yaxis', { type: 'log' }],
+            label: 'Log Y',
+            method: 'relayout',
+          },
+        ],
+        direction: 'left',
+        pad: { r: -10, t: -10 },
+        showactive: true,
+        type: 'buttons',
+        x: -0.1,
+        xanchor: 'left',
+        y: 1.24,
+        yanchor: 'top',
+      },
+    ],
+  });
+
+  const [scatterLayout, setScatterLayout] = useState({
+    width: 345,
+    height: 350,
+    margin: { l: 30, r: 20, b: 30, t: 30, pad: 5 },
+    title: { text: stat },
+    xaxis: { automargin: true, title: names[channelX] },
+    yaxis: { automargin: true, title: names[channelY] },
+  });
+
   return (
     <Grid item>
       {plot === 'scatter' ? (
@@ -69,14 +113,7 @@ function ChannelPlot({ calculations, channelX, channelY, plot }) {
               },
             },
           ]}
-          layout={{
-            width: 345,
-            height: 350,
-            margin: { l: 30, r: 20, b: 30, t: 30, pad: 5 },
-            title: { text: stat },
-            xaxis: { automargin: true, title: names[channelX] },
-            yaxis: { automargin: true, title: names[channelY] },
-          }}
+          layout={scatterLayout}
           config={{
             displaylogo: false,
             modeBarButtonsToRemove: ['toImage', 'autoScale2d', 'zoomIn2d', 'zoomOut2d'],
@@ -84,6 +121,7 @@ function ChannelPlot({ calculations, channelX, channelY, plot }) {
           onSelected={handleSelection}
           onDoubleClick={handleDeselect}
           onClick={handleClick}
+          onUpdate={({ layout }) => setScatterLayout(layout)}
         />
       ) : (
         <Plot
@@ -96,19 +134,13 @@ function ChannelPlot({ calculations, channelX, channelY, plot }) {
               },
             },
           ]}
-          layout={{
-            bargap: 0.1,
-            width: 345,
-            height: 350,
-            margin: { l: 30, r: 20, b: 30, t: 30, pad: 5 },
-            title: { text: stat },
-            xaxis: { automargin: true, title: names[channelX] },
-          }}
+          layout={histLayout}
           config={{
             displaylogo: false,
             modeBarButtonsToRemove: ['toImage', 'autoScale2d', 'zoomIn2d', 'zoomOut2d'],
           }}
           onSelected={handleSelection}
+          onUpdate={({ layout }) => setHistLayout(layout)}
         />
       )}
     </Grid>

--- a/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/ChannelPlot.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/ChannelPlot.js
@@ -56,8 +56,7 @@ function ChannelPlot({ calculations, channelX, channelY, plot }) {
     width: 345,
     height: 350,
     margin: { l: 30, r: 20, b: 30, t: 30, pad: 5 },
-    title: { text: stat },
-    xaxis: { automargin: true, title: names[channelX] },
+    xaxis: { automargin: true, title: stat },
     updatemenus: [
       {
         buttons: [

--- a/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/ChannelPlot.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/ChannelPlot.js
@@ -1,6 +1,6 @@
 import Grid from '@mui/material/Grid';
 import { useSelector } from '@xstate/react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Plot from 'react-plotly.js';
 import {
   useCellTypes,
@@ -9,7 +9,7 @@ import {
   useRaw,
 } from '../../../ProjectContext';
 
-function ChannelPlot({ calculations, channelX, channelY, plot }) {
+function ChannelPlot({ calculations, plot }) {
   const cellTypes = useCellTypes();
   const editCellTypes = useEditCellTypes();
   const raw = useRaw();
@@ -17,6 +17,8 @@ function ChannelPlot({ calculations, channelX, channelY, plot }) {
   const names = useSelector(raw, (state) => state.context.channelNames);
   const selection = useSelector(editCellTypes, (state) => state.context.multiSelected);
   const stat = useSelector(channelExpression, (state) => state.context.calculation);
+  const channelX = useSelector(channelExpression, (state) => state.context.channelX);
+  const channelY = useSelector(channelExpression, (state) => state.context.channelY);
   let colorMap = useSelector(cellTypes, (state) => state.context.colorMap);
   let widthMap = [...colorMap];
   if (colorMap) {
@@ -91,6 +93,13 @@ function ChannelPlot({ calculations, channelX, channelY, plot }) {
     xaxis: { automargin: true, title: names[channelX] },
     yaxis: { automargin: true, title: names[channelY] },
   });
+
+  useEffect(() => {
+    let modLayout = scatterLayout;
+    modLayout.xaxis = { automargin: true, title: names[channelX] };
+    modLayout.yaxis = { automargin: true, title: names[channelY] };
+    setScatterLayout(modLayout);
+  }, [channelX, channelY]);
 
   return (
     <Grid item>

--- a/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/ChannelSelect.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/ChannelSelect.js
@@ -5,24 +5,27 @@ import Grid from '@mui/material/Grid';
 import Radio from '@mui/material/Radio';
 import RadioGroup from '@mui/material/RadioGroup';
 import { useSelector } from '@xstate/react';
-import { useRaw } from '../../../ProjectContext';
+import { useChannelExpression, useRaw } from '../../../ProjectContext';
 
 function ChannelSelect(props) {
-  const { channelX, setChannelX, channelY, setChannelY, plot, setPlot } = props;
+  const { plot, setPlot } = props;
   const raw = useRaw();
+  const channelExpression = useChannelExpression();
   const numChannels = useSelector(raw, (state) => state.context.numChannels);
   const names = useSelector(raw, (state) => state.context.channelNames);
+  const channelX = useSelector(channelExpression, (state) => state.context.channelX);
+  const channelY = useSelector(channelExpression, (state) => state.context.channelY);
 
   const handleChangePlot = (evt) => {
     setPlot(evt.target.value);
   };
 
   const handleChangeX = (evt) => {
-    setChannelX(evt.target.value);
+    channelExpression.send({ type: 'CHANNEL_X', channelX: evt.target.value });
   };
 
   const handleChangeY = (evt) => {
-    setChannelY(evt.target.value);
+    channelExpression.send({ type: 'CHANNEL_Y', channelY: evt.target.value });
   };
 
   return (

--- a/frontend/src/Project/EditControls/CellTypeControls/PlotAndLearnTabs.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/PlotAndLearnTabs.js
@@ -26,8 +26,6 @@ function PlotAndLearnTabs() {
   const sw = useSelector(canvas, (state) => state.context.width);
   const sh = useSelector(canvas, (state) => state.context.height);
   const scale = useSelector(canvas, (state) => state.context.scale);
-  const [channelX, setChannelX] = useState(0);
-  const [channelY, setChannelY] = useState(1);
   const [tab, setTab] = useState(0);
   const [plot, setPlot] = useState('histogram');
 
@@ -86,20 +84,8 @@ function PlotAndLearnTabs() {
             <Calculate />
             {calculations ? (
               <>
-                <ChannelSelect
-                  channelX={channelX}
-                  setChannelX={setChannelX}
-                  channelY={channelY}
-                  setChannelY={setChannelY}
-                  setPlot={setPlot}
-                  plot={plot}
-                />
-                <ChannelPlot
-                  channelX={channelX}
-                  channelY={channelY}
-                  calculations={calculations}
-                  plot={plot}
-                />
+                <ChannelSelect setPlot={setPlot} plot={plot} />
+                <ChannelPlot calculations={calculations} plot={plot} />
                 <AddRemoveCancel />
               </>
             ) : null}

--- a/frontend/src/Project/service/labels/channelExpressionMachine.js
+++ b/frontend/src/Project/service/labels/channelExpressionMachine.js
@@ -244,6 +244,8 @@ const createChannelExpressionMachine = ({ eventBuses }) =>
         raw: null,
         cells: null,
         numCells: null,
+        channelX: 0,
+        channelY: 1,
         calculations: null, // Calculations made across all frames
         embeddings: null, // Imported calculations / embeddings
         reduction: null, // The actual data calculated by the request
@@ -301,6 +303,8 @@ const createChannelExpressionMachine = ({ eventBuses }) =>
                 CHANGE_COLORMAP: {
                   actions: 'setColorMap',
                 },
+                CHANNEL_X: { actions: 'setChannelX' },
+                CHANNEL_Y: { actions: 'setChannelY' },
               },
             },
             calculating: {
@@ -377,6 +381,8 @@ const createChannelExpressionMachine = ({ eventBuses }) =>
         setFeature: assign({ feature: (_, evt) => evt.feature }),
         setStat: assign({ calculation: (_, evt) => evt.stat }),
         setEmbeddings: assign({ embeddings: (_, evt) => evt.embeddings }),
+        setChannelX: assign({ channelX: (_, evt) => evt.channelX }),
+        setChannelY: assign({ channelY: (_, evt) => evt.channelY }),
         toggleWhole: assign({ whole: (ctx) => !ctx.whole }),
         setColorMap: assign({ embeddingColorType: (_, evt) => evt.colorMap }),
         calculateMean: pure((ctx) => {


### PR DESCRIPTION
The UI currently looks pretty ugly and the interfacing between scatter and histogram is still pretty gross (a TODO to potentially also wrap this up in custom plotly buttons could maybe solve this, alternatively hooking into state machine but that might be overkill) but it works. Plotly does indeed have log axes for histograms, I was just looking at the wrong thing.

Also, Plotly related UI stuff is pretty hard to test unfortunately.

Closes #442 