### PR TITLE
Add toggle to NavBar to switch between light and dark mode

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,6 @@
-import { createTheme, StyledEngineProvider, ThemeProvider } from '@mui/material';
+import { createTheme, CssBaseline, StyledEngineProvider, ThemeProvider } from '@mui/material';
 import { styled } from '@mui/system';
+import { useState } from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 import Footer from './Footer';
 import Load from './Load';
@@ -8,12 +9,13 @@ import NavBar from './Navbar';
 import Label from './Project';
 
 const Div = styled('div')``;
-const theme = createTheme();
 
 function App() {
+  const [theme, setTheme] = useState(createTheme({ palette: { mode: 'light' } }));
   return (
     <StyledEngineProvider injectFirst>
       <ThemeProvider theme={theme}>
+        <CssBaseline />
         <Div
           sx={{
             boxSizing: 'border-box',
@@ -22,7 +24,7 @@ function App() {
             flexDirection: 'column',
           }}
         >
-          <NavBar />
+          <NavBar theme={theme.palette.mode} setTheme={setTheme} />
           <Router>
             <Routes>
               <Route path='/' element={<Load />} />

--- a/frontend/src/Navbar.js
+++ b/frontend/src/Navbar.js
@@ -1,6 +1,8 @@
+import DarkModeIcon from '@mui/icons-material/DarkMode';
 import GitHubIcon from '@mui/icons-material/GitHub';
+import LightModeIcon from '@mui/icons-material/LightMode';
 import MoreIcon from '@mui/icons-material/MoreVert';
-import { Box } from '@mui/material';
+import { Box, createTheme } from '@mui/material';
 import AppBar from '@mui/material/AppBar';
 import Button from '@mui/material/Button';
 import IconButton from '@mui/material/IconButton';
@@ -12,7 +14,7 @@ import React, { useState } from 'react';
 
 const Div = styled('div')``;
 
-export default function NavBar() {
+export default function NavBar({ theme, setTheme }) {
   // const [anchorEl, setAnchorEl] = useState(null);
   const [mobileMoreAnchorEl, setMobileMoreAnchorEl] = useState(null);
 
@@ -78,6 +80,21 @@ export default function NavBar() {
               sx={{ display: 'block', borderRadius: 1 }}
             >
               <GitHubIcon sx={{ fontSize: 28 }} />
+            </IconButton>
+            <IconButton
+              onClick={() =>
+                theme === 'light'
+                  ? setTheme(createTheme({ palette: { mode: 'dark' } }))
+                  : setTheme(createTheme({ palette: { mode: 'light' } }))
+              }
+              color='inherit'
+              sx={{ display: 'block', borderRadius: 1 }}
+            >
+              {theme === 'light' ? (
+                <DarkModeIcon sx={{ fontSize: 28 }} />
+              ) : (
+                <LightModeIcon sx={{ fontSize: 28 }} />
+              )}
             </IconButton>
           </Div>
           <Div

--- a/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/CalculateWholeToggle.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/CalculateWholeToggle.js
@@ -31,7 +31,7 @@ function CalculateWholeToggle() {
         placement='right'
       >
         <FormControlLabel
-          sx={{ paddingRight: 1, color: 'rgba(0, 0, 0, 0.6)' }}
+          sx={{ paddingRight: 1 }}
           control={<Switch checked={checked} onChange={handleToggle} />}
           label='All Frames'
           labelPlacement='start'


### PR DESCRIPTION
Adds an icon button to the navbar in the top right to toggle between light and dark mode themes. It turned out that two lines of default dark mode from MUI and adding the cssbaseline component made this essentially good enough out of the box.

Lower priority TODOs:
- The plotly components are still blinding white in dark mode, but they would definitely be a pain to sync up
- Cypress test