### PR TITLE
Fix memory leak caused by continuously returning OutlineCellCanvas

### DIFF
--- a/frontend/src/Project/Canvas/ToolCanvas/AddCellTypeCanvas.js
+++ b/frontend/src/Project/Canvas/ToolCanvas/AddCellTypeCanvas.js
@@ -10,10 +10,6 @@ function AddCellTypeCanvas({ setBitmaps }) {
   const editCellTypes = useEditCellTypes();
   const cell = useSelector(editCellTypes, (state) => state.context.cell);
 
-  if (!cell) {
-    return null;
-  }
-
   return <OutlineCellCanvas setBitmaps={setBitmaps} cell={cell} color={white} />;
 }
 

--- a/frontend/src/Project/Canvas/ToolCanvas/AddDaughterCanvas.js
+++ b/frontend/src/Project/Canvas/ToolCanvas/AddDaughterCanvas.js
@@ -8,10 +8,6 @@ function AddDaughterCanvas({ setBitmaps }) {
   const editDivisions = useEditDivisions();
   const daughter = useSelector(editDivisions, (state) => state.context.daughter);
 
-  if (!daughter) {
-    return null;
-  }
-
   return <OutlineCellCanvas setBitmaps={setBitmaps} cell={daughter} color={white} />;
 }
 

--- a/frontend/src/Project/Canvas/ToolCanvas/OutlineCellCanvas.js
+++ b/frontend/src/Project/Canvas/ToolCanvas/OutlineCellCanvas.js
@@ -74,13 +74,13 @@ function OutlineCellCanvas({ setBitmaps, cell, color }) {
   useEffect(() => {
     const kernel = kernelRef.current;
     // Cell beyond the cell matrix, so it's not in the frame
-    if (cell > cellMatrix[0].length) {
+    if (cell && cell > cellMatrix[0].length) {
       // Remove the tool canvas
       setBitmaps((bitmaps) => {
         const { tool, ...rest } = bitmaps;
         return rest;
       });
-    } else if (labeledArray && cellMatrix) {
+    } else if (cell && labeledArray && cellMatrix) {
       const numValues = cellMatrix.length;
       kernel(labeledArray, cellMatrix, numValues, cell, color);
       // Rerender the parent canvas


### PR DESCRIPTION
## What
In AddCellTypeCanvas.js and AddDaughterCanvas.js, we have:
```python
 if (!cell) {
    return null;
  }
```
I don't have a deep enough understanding of React to know exactly why is the case under the hood, but because of this code, the OutlineCellCanvas component is regenerated without disposing of its memory every time a cell goes from selected to not selected in the context of add mode (which equates to adding a cell to a cell type -> going from returning the component to returning null, alternating). This is especially bad because OutlineCellCanvas calls useCellMatrix(), which is a hook that, if needed, reallocates an approximately N x N matrix where N is the highest ID cell in your current frame. 

Ultimately, this means that for the Keren dataset approximately 120 mb are reallocated everytime you add a cell in the final frame. I'm fairly confident that the issue is gone when this piece of code is removed though (whew).

Closes #460 