### PR TITLE
Refactor idbWebWorker to separate indexedDB storage into multiple obj…

### DIFF
--- a/frontend/src/Project/service/idbWebWorker.js
+++ b/frontend/src/Project/service/idbWebWorker.js
@@ -18,14 +18,14 @@ const idbMachine = createMachine(
     context: {
       db: null,
       projectId: null,
-      project: {
-        raw: null, // Uint8Array[][][]
-        labeled: null, // Int32Array[][][]
-        cells: null, // list of cells (not the Cells object) { value: number, cell, number, t: number}[]
-        cellTypes: null, // list of cell types { id: number, name: string, color: string, cells: number[] }
-        divisions: null, // list of divisions { parent: number, daughters: number[], t: number}[]
-        spots: null, // list of spot coordinates [number, number][]
-      },
+      channels: null, // list of channel names
+      embeddings: null, // list of embedding vectors imported from a cell types model if applicable
+      raw: null, // Uint8Array[][][]
+      labeled: null, // Int32Array[][][]
+      cells: null, // list of cells (not the Cells object) { value: number, cell, number, t: number}[]
+      cellTypes: null, // list of cell types { id: number, name: string, color: string, cells: number[] }
+      divisions: null, // list of divisions { parent: number, daughters: number[], t: number}[]
+      spots: null, // list of spot coordinates [number, number][]
     },
     initial: 'waitForId',
     states: {
@@ -61,23 +61,23 @@ const idbMachine = createMachine(
       idle: {
         on: {
           EDITED_SEGMENT: {
-            target: '.putProject',
+            target: '.putLabeled',
             actions: 'updateLabeled',
             internal: false,
           },
           RESTORED_SEGMENT: {
-            target: '.putProject',
+            target: '.putLabeled',
             actions: 'updateLabeled',
             internal: false,
           },
-          CELLS: { target: '.putProject', actions: 'updateCells', internal: false },
-          CELLTYPES: { target: '.putProject', actions: 'updateCellTypes', internal: false },
+          CELLS: { target: '.putCells', actions: 'updateCells', internal: false },
+          CELLTYPES: { target: '.putCellTypes', actions: 'updateCellTypes', internal: false },
           DIVISIONS: {
-            target: '.putProject',
+            target: '.putDivisions',
             actions: 'updateDivisions',
             internal: false,
           },
-          SPOTS: { target: '.putProject', actions: 'updateSpots', internal: false },
+          SPOTS: { target: '.putSpots', actions: 'updateSpots', internal: false },
         },
         initial: 'idle',
         states: {
@@ -85,58 +85,138 @@ const idbMachine = createMachine(
           putProject: {
             invoke: { src: 'putProject', onDone: 'idle' },
           },
+          putLabeled: {
+            invoke: { src: 'putLabeled', onDone: 'idle' },
+          },
+          putCells: {
+            invoke: { src: 'putCells', onDone: 'idle' },
+          },
+          putCellTypes: {
+            invoke: { src: 'putCellTypes', onDone: 'idle' },
+          },
+          putDivisions: {
+            invoke: { src: 'putDivisions', onDone: 'idle' },
+          },
+          putSpots: {
+            invoke: { src: 'putSpots', onDone: 'idle' },
+          },
         },
       },
     },
   },
   {
     guards: {
-      projectInDb: (ctx, evt) => evt.data !== undefined,
+      projectInDb: (_, evt) => {
+        // Return false if all values in evt.data are undefined
+        return Object.values(evt.data).some((value) => value !== undefined);
+      },
     },
     services: {
       openDB: () =>
-        openDB('deepcell-label', 2, {
+        openDB('deepcell-label', 3, {
           upgrade(db) {
-            db.createObjectStore('projects');
+            const fields = [
+              'cellTypes',
+              'cells',
+              'channels',
+              'divisions',
+              'embeddings',
+              'labeled',
+              'raw',
+              'rawOriginal',
+              'spots',
+            ];
+            for (const field of fields) {
+              db.createObjectStore(field);
+            }
           },
         }),
-      getProject: (ctx) => ctx.db.get('projects', ctx.projectId),
-      putProject: (ctx) => ctx.db.put('projects', ctx.project, ctx.projectId),
+      getProject: async (ctx) => {
+        const cellTypes = await ctx.db.get('cellTypes', ctx.projectId);
+        const cells = await ctx.db.get('cells', ctx.projectId);
+        const channels = await ctx.db.get('channels', ctx.projectId);
+        const divisions = await ctx.db.get('divisions', ctx.projectId);
+        const embeddings = await ctx.db.get('embeddings', ctx.projectId);
+        const labeled = await ctx.db.get('labeled', ctx.projectId);
+        const raw = await ctx.db.get('raw', ctx.projectId);
+        const rawOriginal = await ctx.db.get('rawOriginal', ctx.projectId);
+        const spots = await ctx.db.get('spots', ctx.projectId);
+        const project = {
+          cellTypes: cellTypes,
+          cells: cells,
+          channels: channels,
+          divisions: divisions,
+          embeddings: embeddings,
+          labeled: labeled,
+          raw: raw,
+          rawOriginal: rawOriginal,
+          spots: spots,
+        };
+        return project;
+      },
+      putProject: (ctx) => {
+        ctx.db.put('cellTypes', ctx.cellTypes, ctx.projectId);
+        ctx.db.put('cells', ctx.cells, ctx.projectId);
+        ctx.db.put('channels', ctx.channels, ctx.projectId);
+        ctx.db.put('divisions', ctx.divisions, ctx.projectId);
+        ctx.db.put('embeddings', ctx.embeddings, ctx.projectId);
+        ctx.db.put('labeled', ctx.labeled, ctx.projectId);
+        ctx.db.put('raw', ctx.raw, ctx.projectId);
+        ctx.db.put('rawOriginal', ctx.rawOriginal, ctx.projectId);
+        ctx.db.put('spots', ctx.spots, ctx.projectId);
+      },
+      putLabeled: (ctx) => ctx.db.put('labeled', ctx.labeled, ctx.projectId),
+      putCells: (ctx) => ctx.db.put('cells', ctx.cells, ctx.projectId),
+      putCellTypes: (ctx) => ctx.db.put('cellTypes', ctx.cellTypes, ctx.projectId),
+      putDivisions: (ctx) => ctx.db.put('divisions', ctx.divisions, ctx.projectId),
+      putSpots: (ctx) => ctx.db.put('spots', ctx.spots, ctx.projectId),
     },
     actions: {
-      setProjectId: assign({ projectId: (ctx, evt) => evt.projectId }),
-      setDb: assign({ db: (ctx, evt) => evt.data }),
+      setProjectId: assign({ projectId: (_, evt) => evt.projectId }),
+      setDb: assign({
+        db: (_, evt) => evt.data,
+      }),
       sendProjectNotInDB: sendParent('PROJECT_NOT_IN_DB'),
-      sendLoaded: sendParent((ctx, evt) => ({
+      sendLoaded: sendParent((_, evt) => ({
         type: 'LOADED',
         ...evt.data,
         message: 'from idb web worker machine',
       })),
-      setProject: assign((ctx, evt) => {
+      setProject: assign((_, evt) => {
         const { type, ...project } = evt;
-        return { project };
+        return project;
       }),
-      setProjectFromDb: assign({ project: (ctx, evt) => ({ ...evt.data }) }),
+      setProjectFromDb: assign({
+        cellTypes: (_, evt) => evt.data.cellTypes,
+        cells: (_, evt) => evt.data.cells,
+        channels: (_, evt) => evt.data.channels,
+        divisions: (_, evt) => evt.data.divisions,
+        embeddings: (_, evt) => evt.data.embeddings,
+        labeled: (_, evt) => evt.data.labeled,
+        raw: (_, evt) => evt.data.raw,
+        rawOriginal: (_, evt) => evt.data.rawOriginal,
+        spots: (_, evt) => evt.data.spots,
+      }),
       updateLabeled: assign({
-        project: (ctx, evt) => {
+        labeled: (ctx, evt) => {
           const { t, c } = evt;
-          const labeled = ctx.project.labeled.map((arr, i) =>
+          const labeled = ctx.labeled.map((arr, i) =>
             i === c ? arr.map((arr, j) => (j === t ? evt.labeled : arr)) : arr
           );
-          return { ...ctx.project, labeled };
+          return labeled;
         },
       }),
       updateCells: assign({
-        project: (ctx, evt) => ({ ...ctx.project, cells: evt.cells }),
+        cells: (_, evt) => evt.cells,
       }),
       updateCellTypes: assign({
-        project: (ctx, evt) => ({ ...ctx.project, cellTypes: evt.cellTypes }),
+        cellTypes: (_, evt) => evt.cellTypes,
       }),
       updateDivisions: assign({
-        project: (ctx, evt) => ({ ...ctx.project, divisions: evt.divisions }),
+        divisions: (_, evt) => evt.divisions,
       }),
       updateSpots: assign({
-        project: (ctx, evt) => ({ ...ctx.project, spots: evt.spots }),
+        spots: (_, evt) => evt.spots,
       }),
     },
   }


### PR DESCRIPTION
…ect stores

## What
* We noticed that any time some sort of edit is made (including adding a single cell to a cell type), there would be a large amount of disk usage and waiting before the IndexedDB was done updating. 
* This was because we were using one object to store all persisted context in the IndexedDB, so even adding one element to the cellTypes json, for example, entailed rewriting the entire raw image, labeled mask, etc. to IndexedDB, which was very undesireable especially with larger images
* By separating into separate object stores instead, we can update cellTypes.json, for example, while leaving the raw arrays untouched
