### PR TITLE
Move toggle logic back to state machine, fix various bugs

### DIFF
--- a/frontend/src/Project/EditControls/CellTypeControls/CellTypeControls.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/CellTypeControls.js
@@ -2,8 +2,6 @@
 // the list of cell types, and an editing prompt when adding cells
 
 import { Box, FormLabel } from '@mui/material';
-import { useSelector } from '@xstate/react';
-import { useState } from 'react';
 import { useCellTypes } from '../../ProjectContext';
 import CellTypeAccordionList from './CellTypeUI/CellTypeAccordionList';
 import EditingPrompt from './CellTypeUI/EditingPrompt';
@@ -12,17 +10,15 @@ import ToolBar from './CellTypeUI/ToolBar';
 
 function CellTypeControls() {
   const cellTypes = useCellTypes();
-  const isOnArray = useSelector(cellTypes, (state) => state.context.isOn);
-  const [toggleArray, setToggleArray] = useState(isOnArray);
 
   return (
     <Box id='cell-type-controls' display='flex' flexDirection='column'>
       <FormLabel sx={{ marginBottom: 1 }}>Cell Type Controls</FormLabel>
-      <ToolBar sx={{ marginBottom: 1 }} toggleArray={toggleArray} setToggleArray={setToggleArray} />
+      <ToolBar sx={{ marginBottom: 1 }} />
       <Box sx={{ marginLeft: 0.85 }} display='flex' flexDirection='row'>
-        <ToggleAll toggleArray={toggleArray} setToggleArray={setToggleArray} />
+        <ToggleAll />
       </Box>
-      <CellTypeAccordionList toggleArray={toggleArray} setToggleArray={setToggleArray} />
+      <CellTypeAccordionList />
       <EditingPrompt />
     </Box>
   );

--- a/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/CellTypeAccordion/CellTypeAccordion.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/CellTypeAccordion/CellTypeAccordion.js
@@ -21,7 +21,7 @@ const accordionSummaryStyle = {
 };
 
 function CellTypeAccordion(props) {
-  const { cellType, expanded, setExpanded, toggleArray, setToggleArray } = props;
+  const { cellType, expanded, setExpanded } = props;
 
   const [openColor, toggleColor] = useReducer((v) => !v, false);
 
@@ -41,13 +41,7 @@ function CellTypeAccordion(props) {
     >
       <AccordionSummary style={accordionSummaryStyle}>
         {/* Toggle view of Cell Type with checkbox*/}
-        <CellTypeCheckbox
-          id={cellType.id}
-          color={cellType.color}
-          openColor={openColor}
-          toggleArray={toggleArray}
-          setToggleArray={setToggleArray}
-        />
+        <CellTypeCheckbox id={cellType.id} color={cellType.color} openColor={openColor} />
 
         {/* Slider for cell type opacity on canvas */}
         <CellTypeOpacitySlider id={cellType.id} color={cellType.color} />
@@ -72,12 +66,7 @@ function CellTypeAccordion(props) {
         />
 
         {/* Options button to open menu for name edit and delete */}
-        <EditDeleteMenu
-          id={cellType.id}
-          toggleType={toggleType}
-          toggleArray={toggleArray}
-          setToggleArray={setToggleArray}
-        />
+        <EditDeleteMenu id={cellType.id} toggleType={toggleType} />
       </AccordionSummary>
       <AccordionDetails sx={{ marginTop: '-1em' }}>
         <CellAccordionContents id={cellType.id} name={cellType.name} color={cellType.color} />

--- a/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/CellTypeAccordion/CellTypeCheckbox.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/CellTypeAccordion/CellTypeCheckbox.js
@@ -1,5 +1,6 @@
 import Checkbox from '@mui/material/Checkbox';
-import { useEditCellTypes } from '../../../../ProjectContext';
+import { useSelector } from '@xstate/react';
+import { useCellTypes, useEditCellTypes } from '../../../../ProjectContext';
 
 const checkStyle = {
   marginTop: 40,
@@ -7,15 +8,15 @@ const checkStyle = {
 };
 
 function CellTypeCheckbox(props) {
-  const { color, id, openColor, toggleArray, setToggleArray } = props;
+  const { color, id, openColor } = props;
   const editCellTypes = useEditCellTypes();
-  const isOn = toggleArray[id];
+  const cellTypes = useCellTypes();
+  const isOn = useSelector(cellTypes, (state) => state.context.isOn)[id];
 
   const handleCheck = () => {
     // Handle MUI bug where checkbox is invisible above color popper
     if (!openColor) {
       editCellTypes.send({ type: 'TOGGLE', cellType: id });
-      setToggleArray(toggleArray.map((t, i) => (i === id ? !isOn : t)));
     }
   };
 

--- a/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/CellTypeAccordion/EditDeleteMenu.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/CellTypeAccordion/EditDeleteMenu.js
@@ -17,14 +17,13 @@ const editStyle = {
 };
 
 function EditDeleteMenu(props) {
-  const { toggleType, id, toggleArray, setToggleArray } = props;
+  const { toggleType, id } = props;
   const editCellTypesRef = useEditCellTypes();
   const anchorRef = useRef(null);
   const [openMenu, toggleMenu] = useReducer((v) => !v, false);
 
   // Handler for when a cell type is deleted
   const handleRemove = () => {
-    setToggleArray(toggleArray.filter((e, i) => i !== id));
     editCellTypesRef.send({ type: 'REMOVE_TYPE', cellType: id });
   };
 

--- a/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/CellTypeAccordionList.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/CellTypeAccordionList.js
@@ -22,8 +22,7 @@ const accordionStyle = {
   },
 };
 
-function CellTypeAccordionList(props) {
-  const { toggleArray, setToggleArray } = props;
+function CellTypeAccordionList() {
   const cellTypesRef = useCellTypes();
   const [expanded, setExpanded] = useState(-1);
   const canvasMachine = useCanvas();
@@ -71,8 +70,6 @@ function CellTypeAccordionList(props) {
                       cellType={cellType}
                       expanded={expanded}
                       setExpanded={setExpanded}
-                      toggleArray={toggleArray}
-                      setToggleArray={setToggleArray}
                     />
                   </div>
                 )}

--- a/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToggleAll.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToggleAll.js
@@ -1,24 +1,25 @@
 import { Box, FormLabel } from '@mui/material';
 import Checkbox from '@mui/material/Checkbox';
-import { useEditCellTypes } from '../../../ProjectContext';
+import { useSelector } from '@xstate/react';
+import { useCellTypes, useEditCellTypes } from '../../../ProjectContext';
 
-function ToggleAll({ toggleArray, setToggleArray }) {
+function ToggleAll() {
   const editCellTypes = useEditCellTypes();
+  const cellTypes = useCellTypes();
+  const toggleArray = useSelector(cellTypes, (state) => state.context.isOn);
 
   const handleCheck = () => {
-    if (toggleArray.every((e, i) => e === true || i === 0)) {
+    if (toggleArray.every((e, i) => e === true || e === null || i === 0)) {
       editCellTypes.send({ type: 'UNTOGGLE_ALL' });
-      setToggleArray(toggleArray.map((t) => false));
     } else {
       editCellTypes.send({ type: 'TOGGLE_ALL' });
-      setToggleArray(toggleArray.map((t) => true));
     }
   };
 
   return (
     <Box display='flex' alignItems='center'>
       <Checkbox
-        checked={toggleArray.every((e, i) => e === true || i === 0)}
+        checked={toggleArray.every((e, i) => e === true || e === null || i === 0)}
         onChange={handleCheck}
       />
       <FormLabel sx={{ marginLeft: 0.75 }}>Toggle All</FormLabel>

--- a/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToolBar.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToolBar.js
@@ -8,7 +8,7 @@ function ToolBar(props) {
   return (
     <Grid sx={props.sx} container spacing={1}>
       <Grid item xs={3}>
-        <AddCellTypeLabel toggleArray={props.toggleArray} setToggleArray={props.setToggleArray} />
+        <AddCellTypeLabel />
       </Grid>
       <Grid item xs={3}>
         <OpenMarkerPanel />

--- a/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToolBar/AddCellTypeLabel.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToolBar/AddCellTypeLabel.js
@@ -7,15 +7,13 @@ import { CirclePicker } from 'react-color';
 import { useEditCellTypes } from '../../../../ProjectContext';
 import { colors } from '../CellTypeAccordion/ColorIndicator';
 
-function AddCellTypeLabel(props) {
-  const { toggleArray, setToggleArray } = props;
+function AddCellTypeLabel() {
   const editCellTypesRef = useEditCellTypes();
 
   const [open, toggle] = useReducer((v) => !v, false);
   const anchorRef = useRef(null);
 
   const handleChange = (color) => {
-    setToggleArray(toggleArray.concat([true]));
     editCellTypesRef.send({ type: 'ADD_TYPE', color: color.hex });
     toggle();
   };


### PR DESCRIPTION
## What
* The array that controls what cell types are toggled on or off is moved back to the state machine, as it should be--I found that the fix to #470 was because we have to reassign arrays to new arrays for React to tell that a change was made (the Javascript equivalent of having to assign a variable to list.copy() instead of assigning to list)
* I also fixed bugs relating to how the array is initialized and changed when cell types are turned on, turned off, deleted, added, etc. in various combinations
* **TODO**: The array will still bug out if you, say delete a cell type and then undo that deletion (see #427). This can be fixed by making cellTypesMachine register the UI and have the toggle logic (and opacities should fall under this too) tracked with UNDO/REDO; however, this is a bit of a pain and there are more prioritized things that need to be done, so that will be for a future PR and I'll reopen a issue