### PR TITLE
Increase visibility of multiselected cells for general use

### DIFF
--- a/frontend/cypress/e2e/celltypes.cy.js
+++ b/frontend/cypress/e2e/celltypes.cy.js
@@ -87,8 +87,8 @@ describe('Cell Type Editing', () => {
       cy.get('[data-testid="CheckBoxOutlineBlankIcon"]').eq(1).should('exist');
       cy.get('[data-testid="CheckBoxOutlineBlankIcon"]').eq(2).should('exist');
       cy.get('[data-testid="CheckBoxIcon"]').should('not.exist');
-      cy.get('[type="checkbox"]').eq(1).click();
       cy.get('[type="checkbox"]').eq(2).click();
+      cy.get('[type="checkbox"]').eq(3).click();
       for (let i = 0; i < 3; i++) {
         cy.get('[data-testid="CheckBoxIcon"]').eq(i).should('exist');
       }

--- a/frontend/src/Project/Canvas/ToolCanvas/CellSelectionCanvas.js
+++ b/frontend/src/Project/Canvas/ToolCanvas/CellSelectionCanvas.js
@@ -52,7 +52,7 @@ function CellSelectionCanvas({ setBitmaps }) {
         const ssouth = x < this.constants.w - 2 ? data[y][x + 2] : value;
         const wwest = y > 1 ? data[y - 2][x] : value;
         const eeast = y < this.constants.h - 2 ? data[y + 2][x] : value;
-       
+
         // Outline selected cells on plot
         for (let i = 0; i < numSelected; i++) {
           const cell = selected[i];

--- a/frontend/src/Project/Canvas/ToolCanvas/CellSelectionCanvas.js
+++ b/frontend/src/Project/Canvas/ToolCanvas/CellSelectionCanvas.js
@@ -52,7 +52,7 @@ function CellSelectionCanvas({ setBitmaps }) {
         const ssouth = x < this.constants.w - 2 ? data[y][x + 2] : value;
         const wwest = y > 1 ? data[y - 2][x] : value;
         const eeast = y < this.constants.h - 2 ? data[y + 2][x] : value;
-        
+       
         // Outline selected cells on plot
         for (let i = 0; i < numSelected; i++) {
           const cell = selected[i];

--- a/frontend/src/Project/EditControls/CellTypeControls/CellTypeControls.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/CellTypeControls.js
@@ -1,23 +1,22 @@
 // Controls for cell types menu, including button for adding cell type,
 // the list of cell types, and an editing prompt when adding cells
 
-import { Box, FormLabel } from '@mui/material';
-import { useCellTypes } from '../../ProjectContext';
+import { Box, FormLabel, Grid } from '@mui/material';
 import CellTypeAccordionList from './CellTypeUI/CellTypeAccordionList';
 import EditingPrompt from './CellTypeUI/EditingPrompt';
 import ToggleAll from './CellTypeUI/ToggleAll';
+import ToggleAnimation from './CellTypeUI/ToggleAnimation';
 import ToolBar from './CellTypeUI/ToolBar';
 
 function CellTypeControls() {
-  const cellTypes = useCellTypes();
-
   return (
     <Box id='cell-type-controls' display='flex' flexDirection='column'>
       <FormLabel sx={{ marginBottom: 1 }}>Cell Type Controls</FormLabel>
       <ToolBar sx={{ marginBottom: 1 }} />
-      <Box sx={{ marginLeft: 0.85 }} display='flex' flexDirection='row'>
+      <Grid container sx={{ marginLeft: 0.85 }}>
         <ToggleAll />
-      </Box>
+        <ToggleAnimation />
+      </Grid>
       <CellTypeAccordionList />
       <EditingPrompt />
     </Box>

--- a/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToggleAll.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToggleAll.js
@@ -1,4 +1,4 @@
-import { Box, FormLabel, Tooltip } from '@mui/material';
+import { FormLabel, Grid, Tooltip } from '@mui/material';
 import Checkbox from '@mui/material/Checkbox';
 import { useSelector } from '@xstate/react';
 import { bind, unbind } from 'mousetrap';
@@ -26,15 +26,15 @@ function ToggleAll() {
   }, [handleCheck]);
 
   return (
-    <Tooltip title={<kbd>T</kbd>} placement='right'>
-      <Box display='flex' alignItems='center'>
+    <Grid item xs={5.5} display='flex' alignItems='center'>
+      <Tooltip title={<kbd>T</kbd>} placement='bottom'>
         <Checkbox
           checked={toggleArray.every((e, i) => e === true || e === null || i === 0)}
           onChange={handleCheck}
         />
-        <FormLabel sx={{ marginLeft: 0.75 }}>Toggle All</FormLabel>
-      </Box>
-    </Tooltip>
+      </Tooltip>
+      <FormLabel sx={{ marginLeft: 0.75 }}>Toggle All</FormLabel>
+    </Grid>
   );
 }
 

--- a/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToggleAnimation.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToggleAnimation.js
@@ -1,0 +1,40 @@
+import { FormLabel, Grid, Switch, Tooltip } from '@mui/material';
+import { useSelector } from '@xstate/react';
+import { bind, unbind } from 'mousetrap';
+import React, { useCallback, useEffect } from 'react';
+import { useCanvas } from '../../../ProjectContext';
+
+function ToggleAnimation() {
+  const canvas = useCanvas();
+  const enableAnimations = useSelector(canvas, (state) => state.context.enableAnimations);
+
+  const handleCheck = useCallback(() => {
+    canvas.send({ type: 'TOGGLE_ANIMATIONS' });
+  }, [canvas]);
+
+  useEffect(() => {
+    bind('shift+a', handleCheck);
+    return () => {
+      unbind('shift+a', handleCheck);
+    };
+  }, [handleCheck]);
+
+  return (
+    <Grid item xs={6} display='flex' alignItems='center'>
+      <FormLabel sx={{ marginLeft: 0.75 }}>Animations</FormLabel>
+      <Tooltip
+        title={
+          <span>
+            WARNING: Enables flashing animation for highlighted cells <br />
+            <kbd>Shift</kbd> + <kbd>A</kbd>
+          </span>
+        }
+        placement='bottom'
+      >
+        <Switch checked={enableAnimations} onChange={handleCheck} />
+      </Tooltip>
+    </Grid>
+  );
+}
+
+export default ToggleAnimation;

--- a/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToolBar.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToolBar.js
@@ -1,5 +1,6 @@
 import { Grid } from '@mui/material';
 import AddCellTypeLabel from './ToolBar/AddCellTypeLabel';
+import HighlightMultiLabel from './ToolBar/HighlightMultiLabel';
 import HoverToggle from './ToolBar/HoverToggle';
 import ModeToggle from './ToolBar/ModeToggle';
 import OpenMarkerPanel from './ToolBar/OpenMarkerPanel';
@@ -7,17 +8,20 @@ import OpenMarkerPanel from './ToolBar/OpenMarkerPanel';
 function ToolBar(props) {
   return (
     <Grid sx={props.sx} container spacing={1}>
-      <Grid item xs={3}>
+      <Grid item xs={2.4}>
         <AddCellTypeLabel />
       </Grid>
-      <Grid item xs={3}>
+      <Grid item xs={2.4}>
         <OpenMarkerPanel />
       </Grid>
-      <Grid item xs={3}>
+      <Grid item xs={2.4}>
         <ModeToggle />
       </Grid>
-      <Grid item xs={3}>
+      <Grid item xs={2.4}>
         <HoverToggle />
+      </Grid>
+      <Grid item xs={2.4}>
+        <HighlightMultiLabel />
       </Grid>
     </Grid>
   );

--- a/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToolBar/AddCellTypeLabel.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToolBar/AddCellTypeLabel.js
@@ -20,7 +20,7 @@ function AddCellTypeLabel() {
 
   return (
     <>
-      <Tooltip title='Add New Cell Type'>
+      <Tooltip title='Add New Cell Type' placement='top'>
         <IconButton
           ref={anchorRef}
           color='primary'

--- a/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToolBar/HighlightMultiLabel.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToolBar/HighlightMultiLabel.js
@@ -1,0 +1,65 @@
+import HighlightTwoToneIcon from '@mui/icons-material/HighlightTwoTone';
+import { IconButton, Tooltip } from '@mui/material';
+import { useSelector } from '@xstate/react';
+import { bind, unbind } from 'mousetrap';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCellTypes, useEditCellTypes } from '../../../../ProjectContext';
+
+function HighlightMultiLabel() {
+  const editCellTypes = useEditCellTypes();
+  const cellTypes = useCellTypes();
+  const feature = useSelector(cellTypes, (state) => state.context.feature);
+  const cellTypesCurrent = useSelector(cellTypes, (state) => state.context.cellTypes).filter(
+    (cellType) => cellType.feature === feature
+  );
+  const multiSelected = useSelector(editCellTypes, (state) => state.context.multiSelected);
+  const [highlighting, setHighlighting] = useState(multiSelected.length > 0 ? true : false);
+
+  // Get cells with multiple labels
+  const multiLabelCells = useMemo(() => {
+    const cellTypeCounts = cellTypesCurrent.reduce((counts, cellType) => {
+      cellType.cells.forEach((cell) => {
+        counts[cell] = (counts[cell] || 0) + 1;
+      });
+      return counts;
+    }, {});
+    return Object.keys(cellTypeCounts)
+      .filter((cell) => cellTypeCounts[cell] > 1)
+      .map((cell) => parseInt(cell, 10));
+  }, [cellTypesCurrent]);
+
+  // Select cells with multiple labels or deselect all
+  const handleHighlight = useCallback(() => {
+    if (highlighting) {
+      editCellTypes.send({ type: 'MULTISELECTION', selected: [] });
+      setHighlighting(false);
+    } else {
+      editCellTypes.send({ type: 'MULTISELECTION', selected: multiLabelCells });
+      setHighlighting(true);
+    }
+  }, [editCellTypes, highlighting, multiLabelCells]);
+
+  useEffect(() => {
+    bind('space', handleHighlight);
+    return () => {
+      unbind('space', handleHighlight);
+    };
+  }, [handleHighlight]);
+
+  return (
+    <Tooltip
+      title={
+        <span>
+          Highlight multi-labels <kbd>Space</kbd>
+        </span>
+      }
+      placement='top'
+    >
+      <IconButton onClick={handleHighlight} color='primary' sx={{ width: '100%', borderRadius: 1 }}>
+        <HighlightTwoToneIcon />
+      </IconButton>
+    </Tooltip>
+  );
+}
+
+export default HighlightMultiLabel;

--- a/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToolBar/HoverToggle.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToolBar/HoverToggle.js
@@ -14,9 +14,9 @@ function HoverToggle() {
   }, [editCellTypes]);
 
   useEffect(() => {
-    bind('shift', handleHovering);
+    bind('x', handleHovering);
     return () => {
-      unbind('shift', handleHovering);
+      unbind('x', handleHovering);
     };
   }, [handleHovering]);
 
@@ -25,14 +25,15 @@ function HoverToggle() {
       title={
         hoveringCard ? (
           <span>
-            Hover for cell type(s) <kbd>Shift</kbd>
+            Hover for cell type(s) <kbd>X</kbd>
           </span>
         ) : (
           <span>
-            Hover disabled <kbd>Shift</kbd>
+            Hover disabled <kbd>X</kbd>
           </span>
         )
       }
+      placement='top'
     >
       <IconButton onClick={handleHovering} color='primary' sx={{ width: '100%', borderRadius: 1 }}>
         {hoveringCard ? <SpeakerNotesTwoToneIcon /> : <SpeakerNotesOffTwoToneIcon />}

--- a/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToolBar/ModeToggle.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToolBar/ModeToggle.js
@@ -36,6 +36,7 @@ function ModeToggle() {
           </span>
         )
       }
+      placement='top'
     >
       <IconButton onClick={handleMode} color='primary' sx={{ width: '100%', borderRadius: 1 }}>
         {mode === 'overwrite' ? <LayersClearTwoToneIcon /> : <LayersTwoToneIcon />}

--- a/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToolBar/OpenMarkerPanel.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/ToolBar/OpenMarkerPanel.js
@@ -26,6 +26,7 @@ function OpenMarkerPanel() {
             Open Marker Panel <kbd>P</kbd>
           </span>
         }
+        placement='top'
       >
         <IconButton
           color='primary'

--- a/frontend/src/Project/EditControls/EditTabs.js
+++ b/frontend/src/Project/EditControls/EditTabs.js
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import { useLabelMode, useSpots } from '../ProjectContext';
 
 const tabKeybinds = {
-  segment: ['b', 'e', 'x', 'k', 'g', 'w', 'q'], // Remove 'm' and 't' so we can use it for cellTypes
+  segment: ['b', 'e', 'k', 'g', 'w', 'q'], // Remove 'm', 'x', and 't' so we can use it for cellTypes
   cells: ['Backspace', 'r', 's'],
 };
 

--- a/frontend/src/Project/service/canvasMachine.js
+++ b/frontend/src/Project/service/canvasMachine.js
@@ -39,6 +39,7 @@ const createCanvasMachine = ({ undoRef, eventBuses }) =>
         dx: 0,
         dy: 0,
         panOnDrag: true,
+        enableAnimations: false, // Whether to enable animations like flashing highlighted cells
       },
       invoke: [
         { id: 'eventBus', src: fromEventBus('canvas', () => eventBuses.canvas) },
@@ -67,6 +68,7 @@ const createCanvasMachine = ({ undoRef, eventBuses }) =>
           cond: 'newCoordinates',
           actions: ['setCoordinates', forwardTo('eventBus')],
         },
+        TOGGLE_ANIMATIONS: { actions: 'toggleAnimations' },
         'keydown.Space': '.pan.grab',
         'keyup.Space': '.pan.interactive',
       },
@@ -288,6 +290,7 @@ const createCanvasMachine = ({ undoRef, eventBuses }) =>
           return { type: 'SET_POSITION', zoom: newZoom, sx: newSx, sy: newSy };
         }),
         setPanOnDrag: assign({ panOnDrag: (_, evt) => evt.panOnDrag }),
+        toggleAnimations: assign({ enableAnimations: (ctx) => !ctx.enableAnimations }),
         sendToEventBus: forwardTo('eventBus'),
       },
     }


### PR DESCRIPTION
## What
* Addressing #480 and #464 
* We change the multiselect canvas rendering to increase its visibility--the width of the white outlines is increased to 2, and the interior is lit up with white 50% opacity pixels. Additionally, an animation can be enabled that alternates the interior on and off to create a light-up flashing effect (there is a warning on the toggle for people sensitive to flashing lights)
* We leverage this new multiselect to add a button + keybinding to multiselect all cells with multiple labels, for reasoning explained in #464 
* Some additional UI and keybinding tweaks were made for QOL, such as moving tooltip positions and changing keybindings, most notably hover toggle from Shift to X
* Importantly, this canvas can be extended naturally to account for, say, high uncertainty cells from the in-browser trainer or imported from a model prediction for future features/use
