### PR TITLE
Add API endpoint for creating projects from zip file

### DIFF
--- a/backend/deepcell_label/blueprints_test.py
+++ b/backend/deepcell_label/blueprints_test.py
@@ -43,6 +43,22 @@ def test_create_project(client, mocker):
     response = client.post('/api/project', data={'images': 'https://test.com'})
     assert response.status_code == 200
 
+# Test create_project_from_zip
+def test_create_project_from_zip(client):
+    # Create temporary zip file
+    with tempfile.NamedTemporaryFile(suffix='.zip') as zf:
+        # Create a dummy tiff in the zip file
+        with TiffWriter(zf) as writer:
+            writer.save(np.zeros((1, 1, 1, 1)))
+            zf.seek(0)
+        # Send zip file to server
+        data = {'zip': (zf, 'test.zip')}
+        response = client.post(
+            '/api/project/zip', data=data, content_type='multipart/form-data'
+        )
+    assert response.status_code == 200
+        
+
 
 def test_create_project_dropped_npz(client):
     with tempfile.NamedTemporaryFile() as f:


### PR DESCRIPTION
Adds an API endpoint for creating projects with a zipfile opened in memory. This should make it easy to programmatically create DCL projects by simply sending a POST request to /api/project/zip with a field for 'zip' @rossbar ! 

I think this could probably be consolidated with the 'dropped' endpoint as well, but this is the simple and fast solution for now. 