### PR TITLE
Adjust height and margin of cell expression plot

### DIFF
--- a/frontend/src/Project/EditControls/CellTypeControls/CellInfoUI/CellExpressions.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/CellInfoUI/CellExpressions.js
@@ -40,8 +40,8 @@ function CellExpressions({ calculations }) {
       ]}
       layout={{
         width: 345,
-        height: 300,
-        margin: { l: maxNameLength * 8.5, r: 20, b: 30, t: 20, pad: 5 },
+        height: channelNames.length * 13 + 100,
+        margin: { l: maxNameLength * 5 + 50, r: 20, b: 30, t: 20, pad: 5 },
         xaxis: { automargin: true },
         yaxis: {
           autorange: 'reversed',


### PR DESCRIPTION
## What
* Adjusts the height and margin of cell expression plot to account for larger number of channels and variety of channel name lengths as referenced in #484 . This is difficult to test since we don't have a easy way of changing the channel names list so this may have issues again in the future, but the plot looked good for a variety of lists that I looked at (Hickey, Liu, 2d example)
