### PR TITLE
Change sizing for modal fit

### DIFF
--- a/frontend/src/Project/EditControls/CellTypeControls/TrainingUI/ConfusionMatrix.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/TrainingUI/ConfusionMatrix.js
@@ -43,7 +43,7 @@ function ConfusionMatrix({ confusionMatrix }) {
   ];
 
   const width = window.innerWidth * 0.4;
-  const height = window.innerHeight * 0.62;
+  const height = window.innerHeight * 0.55;
 
   return (
     <Plot

--- a/frontend/src/Project/EditControls/CellTypeControls/TrainingUI/DistributionHistogram.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/TrainingUI/DistributionHistogram.js
@@ -24,7 +24,7 @@ function DistributionHistogram({ trainCounts }) {
   const lightenedColors = colors.map((color) => lightenColor(color));
 
   const width = window.innerWidth * 0.4;
-  const height = window.innerHeight * 0.62;
+  const height = window.innerHeight * 0.55;
 
   return (
     <Grid item>

--- a/frontend/src/Project/EditControls/CellTypeControls/TrainingUI/PredictionModal.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/TrainingUI/PredictionModal.js
@@ -11,7 +11,7 @@ function PredictionModal({ open, setOpen }) {
     left: '50%',
     transform: 'translate(-50%, -50%)',
     width: '30vw',
-    height: '45vh',
+    height: '50vh',
     bgcolor: 'background.paper',
     borderRadius: 2,
     boxShadow: 24,

--- a/frontend/src/Project/EditControls/CellTypeControls/TrainingUI/TrainingPlot.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/TrainingUI/TrainingPlot.js
@@ -11,7 +11,7 @@ function TrainingPlot() {
   const epochs = trainLogs.map((_, i) => i);
 
   const width = window.innerWidth * 0.4;
-  const height = window.innerHeight * 0.62;
+  const height = window.innerHeight * 0.55;
 
   return (
     <Grid item>


### PR DESCRIPTION
For some reason, (perhaps from Chrome updates?) some sizing issues cropped up on some of the components in the modals, so some size changes are made to make things fit properly in their containers. 