### PR TITLE
Cell type and channel name state management fixes

### DIFF
--- a/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/CellTypeAccordion/EditNameField.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/CellTypeUI/CellTypeAccordion/EditNameField.js
@@ -1,6 +1,6 @@
 import TextField from '@mui/material/TextField';
 import Typography from '@mui/material/Typography';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useEditCellTypes } from '../../../../ProjectContext';
 
 const textStyle = {
@@ -11,7 +11,7 @@ const textStyle = {
 
 function EditNameField(props) {
   const { id, cellName, typing, toggleType } = props;
-  const [name, setName] = useState(cellName);
+  const [name, setName] = useState(null);
   const editCellTypesRef = useEditCellTypes();
   const focusRef = useRef(null);
 
@@ -35,6 +35,11 @@ function EditNameField(props) {
       editCellTypesRef.send({ type: 'NAME', cellType: id, name: name });
     }
   };
+
+  // Needed so that name updates on change and undo
+  useEffect(() => {
+    setName(cellName);
+  }, [cellName]);
 
   return (
     <div style={textStyle}>

--- a/frontend/src/Project/service/idbMachine.js
+++ b/frontend/src/Project/service/idbMachine.js
@@ -19,6 +19,7 @@ function createIDBMachine({ projectId, eventBuses }) {
         {
           src: fromEventBus('IDB', () => eventBuses.arrays, ['EDITED_SEGMENT', 'RESTORED_SEGMENT']),
         },
+        { src: fromEventBus('IDB', () => eventBuses.raw, 'CHANNEL_NAMES') },
         { src: fromEventBus('IDB', () => eventBuses.cells, 'CELLS') },
         { src: fromEventBus('IDB', () => eventBuses.divisions, 'DIVISIONS') },
         { src: fromEventBus('IDB', () => eventBuses.cellTypes, 'CELLTYPES') },
@@ -77,6 +78,7 @@ function createIDBMachine({ projectId, eventBuses }) {
             RESTORED_SEGMENT: { actions: forwardTo('idb') },
             CELLS: { actions: forwardTo('idb') },
             CELLTYPES: { actions: forwardTo('idb') },
+            CHANNEL_NAMES: { actions: forwardTo('idb') },
             DIVISIONS: { actions: forwardTo('idb') },
             SPOTS: { actions: forwardTo('idb') },
           },

--- a/frontend/src/Project/service/idbWebWorker.js
+++ b/frontend/src/Project/service/idbWebWorker.js
@@ -72,6 +72,11 @@ const idbMachine = createMachine(
           },
           CELLS: { target: '.putCells', actions: 'updateCells', internal: false },
           CELLTYPES: { target: '.putCellTypes', actions: 'updateCellTypes', internal: false },
+          CHANNEL_NAMES: {
+            target: '.putChannels',
+            actions: 'updateChannels',
+            internal: false,
+          },
           DIVISIONS: {
             target: '.putDivisions',
             actions: 'updateDivisions',
@@ -93,6 +98,9 @@ const idbMachine = createMachine(
           },
           putCellTypes: {
             invoke: { src: 'putCellTypes', onDone: 'idle' },
+          },
+          putChannels: {
+            invoke: { src: 'putChannels', onDone: 'idle' },
           },
           putDivisions: {
             invoke: { src: 'putDivisions', onDone: 'idle' },
@@ -168,6 +176,7 @@ const idbMachine = createMachine(
       putLabeled: (ctx) => ctx.db.put('labeled', ctx.labeled, ctx.projectId),
       putCells: (ctx) => ctx.db.put('cells', ctx.cells, ctx.projectId),
       putCellTypes: (ctx) => ctx.db.put('cellTypes', ctx.cellTypes, ctx.projectId),
+      putChannels: (ctx) => ctx.db.put('channels', ctx.channels, ctx.projectId),
       putDivisions: (ctx) => ctx.db.put('divisions', ctx.divisions, ctx.projectId),
       putSpots: (ctx) => ctx.db.put('spots', ctx.spots, ctx.projectId),
     },
@@ -211,6 +220,9 @@ const idbMachine = createMachine(
       }),
       updateCellTypes: assign({
         cellTypes: (_, evt) => evt.cellTypes,
+      }),
+      updateChannels: assign({
+        channels: (_, evt) => evt.channelNames,
       }),
       updateDivisions: assign({
         divisions: (_, evt) => evt.divisions,

--- a/frontend/src/Project/service/raw/rawMachine.js
+++ b/frontend/src/Project/service/raw/rawMachine.js
@@ -86,7 +86,7 @@ const createRawMachine = ({ projectId, eventBuses, undoRef }) =>
                 EDIT_CHANNEL: {
                   actions: ['editLayer'],
                 },
-                EDIT_NAME: { actions: 'editChannelName' },
+                EDIT_NAME: { actions: ['editChannelName', 'sendChannelNames'] },
               },
             },
             grayscale: {
@@ -121,11 +121,18 @@ const createRawMachine = ({ projectId, eventBuses, undoRef }) =>
         }),
         editChannelName: assign({
           channelNames: (ctx, evt) => {
-            let channelNames = ctx.channelNames;
+            let channelNames = [...ctx.channelNames];
             channelNames[evt.channel] = evt.name;
             return channelNames;
           },
         }),
+        // Send an event to event bus that channel names have been edited
+        sendChannelNames: send(
+          (ctx) => ({ type: 'CHANNEL_NAMES', channelNames: ctx.channelNames }),
+          {
+            to: 'eventBus',
+          }
+        ),
         editLayer: assign({
           layersOpen: ({ channelNames, layersOpen }, { channel, index }) => [
             ...layersOpen.map((c, i) => (i === index ? channelNames[channel] : c)),


### PR DESCRIPTION
## What
* Fixes a bug where undoing a cell type name change does not update the UI immediately (#448)
* Fixes bug where changing channel names does not update UI immediately (#496) (see description of #473 )
* Channel names are now updated in IDB (aka edited channel names will persist on reload)