### PR TITLE
Remove cell type selection component when no cell types

### DIFF
--- a/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/AddRemoveCancel.js
+++ b/frontend/src/Project/EditControls/CellTypeControls/ChannelExpressionUI/AddRemoveCancel.js
@@ -40,7 +40,7 @@ function AddRemoveCancel() {
     editCellTypes.send({ type: 'MULTIREMOVE', cellType: cellTypeIds[cellType] });
   };
 
-  return (
+  return cellTypeIds.length > 0 ? (
     <>
       <Grid item>
         <TextField
@@ -103,7 +103,7 @@ function AddRemoveCancel() {
         </Button>
       </Grid>
     </>
-  );
+  ) : null;
 }
 
 export default AddRemoveCancel;


### PR DESCRIPTION
## What
* When there are no cell types the cell type selection component for adding or removing selected cells from a cell type on the right panel throws warnings; by checking if there are cell types, this warning will be suppressed
