### PR TITLE
MAINT: Fix deprecated code and unpin numpy.

### DIFF
--- a/backend/deepcell_label/loaders.py
+++ b/backend/deepcell_label/loaders.py
@@ -410,10 +410,10 @@ def load_zip_tiffs(zf, filename):
                 batches[batch] = np.stack(features, axis=-1)
             # Stack batches on first axis
             batches = map(lambda x: x[1], sorted(batches.items()))
-            array = np.stack(batches, axis=0)
+            array = np.stack(list(batches), axis=0)
             return array
         else:  # Use each tiff as a channel and stack on the last axis
-            y = np.stack(tiffs.values(), axis=-1)
+            y = np.stack(list(tiffs.values()), axis=-1)
             # Add Z axis
             if y.ndim == 3:
                 y = y[np.newaxis, ...]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,7 +8,7 @@ flask-sqlalchemy~=2.5.1
 imagecodecs~=2022.2.22
 matplotlib~=3.5.0
 mysqlclient~=2.1.0
-numpy~=1.21.4
+numpy
 pillow~=9.0.1
 python-decouple~=3.1
 python-dotenv~=0.19.2


### PR DESCRIPTION
## What
* Fix a few instances in the code where `np.stack` was called on non-iterables

## Why
* This pattern was deprecated - fixing it allows us to upgrade to latest numpy
