### PR TITLE
MAINT: Rm dependency on matplotlib.

### DIFF
--- a/backend/deepcell_label/label.py
+++ b/backend/deepcell_label/label.py
@@ -7,7 +7,6 @@ import zipfile
 
 import numpy as np
 import skimage
-from matplotlib.colors import Normalize
 from skimage import filters
 from skimage.exposure import rescale_intensity
 from skimage.measure import regionprops
@@ -374,7 +373,15 @@ class Edit(object):
 
         # Contour the cell
         init_level_set = mask[top:bottom, left:right]
-        image = Normalize()(self.raw)[top:bottom, left:right]
+        # Normalize to range [0., 1.]
+        _vmin, _vmax = self.raw.min(), self.raw.max()
+        if _vmin == _vmax:
+            image = np.zeros_like(self.raw)
+        else:
+            image = self.raw.copy()
+            image -= _vmin
+            image /= _vmax - _vmin
+        image = image[top:bottom, left:right]
         contoured = morphological_chan_vese(
             image, iterations, init_level_set=init_level_set
         )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,7 +6,6 @@ flask-dropzone~=1.6.0
 flask-monitoringdashboard~=3.1.1
 flask-sqlalchemy~=2.5.1
 imagecodecs~=2022.2.22
-matplotlib~=3.5.0
 mysqlclient~=2.1.0
 numpy
 pillow~=9.0.1


### PR DESCRIPTION
Matplotlib was only used in one place for normalization. Replace the usage to reduce dependency footprint.