### PR TITLE
disabled cells opacity for cell types

### DIFF
--- a/frontend/src/Project/DisplayControls/LabeledControls/CellsOpacitySlider.js
+++ b/frontend/src/Project/DisplayControls/LabeledControls/CellsOpacitySlider.js
@@ -3,7 +3,7 @@ import Slider from '@mui/material/Slider';
 // import Tooltip from '@mui/material/Tooltip';
 import { useSelector } from '@xstate/react';
 import React, { useEffect } from 'react';
-import { useLabeled, useMousetrapRef } from '../../ProjectContext';
+import { useLabeled, useMousetrapRef, useLabelMode } from '../../ProjectContext';
 
 let numMounted = 0;
 
@@ -17,6 +17,9 @@ function CellsOpacitySlider() {
     labeled.send({ type: 'SET_CELLS_OPACITY', opacity: newValue });
 
   const handleDoubleClick = () => labeled.send({ type: 'SET_CELLS_OPACITY', opacity: 0.3 }); // [0.3, 1] for range slider
+
+  const labelMode = useLabelMode();
+  const isCellTypes = useSelector(labelMode, (state) => state.matches('editCellTypes'));
 
   useEffect(() => {
     const listener = (e) => {
@@ -47,7 +50,7 @@ function CellsOpacitySlider() {
   return (
     <Tooltip title={<kbd>Z</kbd>} placement='right'>
       <Slider
-        value={opacity}
+        value={isCellTypes? 0 : opacity}
         min={0}
         max={1}
         // track={false}
@@ -57,6 +60,7 @@ function CellsOpacitySlider() {
         onDoubleClick={handleDoubleClick}
         componentsProps={{ input: { ref: inputRef } }}
         sx={{ py: 0, '& .MuiSlider-thumb': { height: 15, width: 15 } }}
+        disabled={isCellTypes}
       />
     </Tooltip>
   );


### PR DESCRIPTION
Because cells opacity is always transparent, disable the Cells Opacity slider for the cell types case.
