### PR TITLE
MAINT: Pin werkzeug for flask v2 compatibility.

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 boto3~=1.26.153
 flask~=2.0.2
+werkzeug<3
 flask-compress~=1.10.1
 flask-cors~=3.0.10
 flask-dropzone~=1.6.0


### PR DESCRIPTION
Werkzeug v3 removes functionality that flask 2 depends on, but flask 2.0.2 doesn't contain an upper bound pin on the major version of werkzeug, so add it manually here.